### PR TITLE
chore(release): @wisecom/atlas-cli and @wisecom/atlas-sdk 2.0.0-beta.1

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,71 @@
+# @wisecom/atlas-cli
+
+Command-line tool for [Atlas](https://github.com/wisecom-oy/atlas) — secure Microsoft 365 backup and restore to S3-compatible object storage.
+
+Protects Outlook mailboxes, OneDrive files, and SharePoint document libraries with per-tenant envelope encryption (AES-256-GCM), content-addressed deduplication, and incremental delta sync via Microsoft Graph.
+
+## Requirements
+
+- Node.js 20 or later
+
+## Install
+
+```bash
+npm install -g @wisecom/atlas-cli
+```
+
+Beta releases use the `beta` dist-tag:
+
+```bash
+npm install -g @wisecom/atlas-cli@beta
+```
+
+## Quick start
+
+Configure credentials in a `.env` file (see [Configuration](https://wisecom-oy.github.io/atlas/configuration)):
+
+```bash
+cp .env.example .env
+```
+
+Run your first backup:
+
+```bash
+# Outlook — single mailbox
+atlas outlook backup --mailbox user@company.com
+
+# OneDrive
+atlas onedrive backup -o user@company.com
+
+# SharePoint
+atlas sharepoint backup --site https://contoso.sharepoint.com/sites/Engineering
+```
+
+## Common commands
+
+| Command | Description |
+| ------- | ----------- |
+| `atlas outlook backup` | Back up mailboxes to object storage |
+| `atlas outlook restore` | Restore from a snapshot |
+| `atlas outlook verify` | Verify snapshot integrity |
+| `atlas onedrive backup` | Back up a user's OneDrive |
+| `atlas sharepoint backup` | Back up a SharePoint site |
+| `atlas stats` | Storage statistics |
+| `atlas storage-check` | Validate S3 Object Lock readiness |
+| `atlas replicate` | Replicate snapshots to a secondary target |
+
+Run `atlas --help` or `atlas <command> --help` for full flag reference.
+
+## Programmatic use
+
+For embedding Atlas in Node.js applications, use [`@wisecom/atlas-sdk`](https://www.npmjs.com/package/@wisecom/atlas-sdk) instead.
+
+## Documentation
+
+Full guides, security model, and CLI reference:
+
+**https://wisecom-oy.github.io/atlas/**
+
+## License
+
+Apache-2.0 — Copyright 2026 [Wisecom Oy](https://wisecom.fi)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,16 +1,25 @@
 {
   "name": "@wisecom/atlas-cli",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "CLI for Atlas — secure Microsoft 365 backup and restore to S3-compatible storage.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wisecom-oy/atlas.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://wisecom-oy.github.io/atlas/reference/cli",
+  "bugs": {
+    "url": "https://github.com/wisecom-oy/atlas/issues"
+  },
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "bin": {
-    "atlas": "./dist/cli.mjs"
+    "atlas": "dist/cli.mjs"
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
   "exports": {
     ".": {
       "import": {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,78 @@
+# @wisecom/atlas-sdk
+
+Programmatic API for embedding [Atlas](https://github.com/wisecom-oy/atlas) — Microsoft 365 backup and restore — in Node.js applications.
+
+Use this package for custom schedulers, multi-tenant SaaS, backup portals, and automation that needs typed control over Outlook, OneDrive, and SharePoint workloads. All internal modules are bundled; install this package alone with no peer `@wisecom/atlas-*` dependencies.
+
+## Requirements
+
+- Node.js 20 or later
+
+## Install
+
+```bash
+npm add @wisecom/atlas-sdk
+```
+
+Beta releases use the `beta` dist-tag:
+
+```bash
+npm add @wisecom/atlas-sdk@beta
+```
+
+## Quick start
+
+Config is explicit at construction time — the SDK does **not** read `.env` files or environment variables.
+
+```typescript
+import { createAtlasInstance } from '@wisecom/atlas-sdk';
+
+const atlas = createAtlasInstance({
+  tenantId: 'your-azure-tenant-id',
+  clientId: 'app-client-id',
+  clientSecret: 'app-client-secret',
+  s3Endpoint: 'http://localhost:9000',
+  s3AccessKey: 'minioadmin',
+  s3SecretKey: 'minioadmin',
+  encryptionPassphrase: 'my-secret-passphrase',
+});
+
+// Outlook backup
+await atlas.outlook.backup({ mailbox: 'user@company.com' });
+
+// OneDrive backup
+await atlas.onedrive.backup({ owner: 'user@company.com' });
+
+// SharePoint backup
+await atlas.sharepoint.backup({
+  siteUrl: 'https://contoso.sharepoint.com/sites/Engineering',
+});
+```
+
+## API overview
+
+| Namespace / method | Purpose |
+| ------------------ | ------- |
+| `atlas.outlook` | Mailbox backup, restore, verify, catalog |
+| `atlas.onedrive` | OneDrive backup and verification |
+| `atlas.sharepoint` | SharePoint site backup and restore |
+| `atlas.getBucketStats()` | Storage statistics |
+| `atlas.checkStorage()` | S3 Object Lock readiness |
+| `atlas.replicateSnapshot()` | Cross-region replication |
+| `createStorageTarget()` | Configure secondary S3 targets |
+
+The SDK re-exports domain types, port interfaces, and `GRAPH_SERVICE_LIMITS` from a single import.
+
+## CLI alternative
+
+For shell-based operations, cron jobs, and operator workflows, use [`@wisecom/atlas-cli`](https://www.npmjs.com/package/@wisecom/atlas-cli).
+
+## Documentation
+
+Full SDK reference, examples, and security model:
+
+**https://wisecom-oy.github.io/atlas/reference/sdk**
+
+## License
+
+Apache-2.0 — Copyright 2026 [Wisecom Oy](https://wisecom.fi)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,13 +1,22 @@
 {
   "name": "@wisecom/atlas-sdk",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Programmatic API for embedding Atlas M365 backup and restore in Node.js applications.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wisecom-oy/atlas.git",
+    "directory": "packages/sdk"
+  },
+  "homepage": "https://wisecom-oy.github.io/atlas/reference/sdk",
+  "bugs": {
+    "url": "https://github.com/wisecom-oy/atlas/issues"
+  },
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
## Summary
- Bump `@wisecom/atlas-cli` and `@wisecom/atlas-sdk` to `2.0.0-beta.1`
- Add package-level README files for npm
- Add `repository`, `homepage`, and `bugs` metadata for provenance validation in CI trusted publishing

## Test plan
- [ ] Merge PR
- [ ] Push tag `v2.0.0-beta.1` to trigger publish workflow
- [ ] Verify both packages appear on npm with README content


Made with [Cursor](https://cursor.com)