### PR TITLE
feat(outlook): shared mailbox backup, non-zero exit on tenant failures (2.0.0-beta.2)

### DIFF
--- a/docs/azure-ad-setup.md
+++ b/docs/azure-ad-setup.md
@@ -11,7 +11,7 @@ In the Azure Portal, register an application with the following **Application** 
 | `Mail.Read`            | Read mailbox contents via Graph API                     | Backup, list, read, save, verify |
 | `Mail.ReadWrite`       | Restore messages and create folders in target mailboxes | Restore only                     |
 | `User.Read.All`        | Enumerate users and resolve mailbox IDs                 | User discovery                   |
-| `MailboxSettings.Read` | Read mailbox metadata and folder structure              | Folder enumeration               |
+| `MailboxSettings.Read` | Read mailbox metadata and folder structure; shared-mailbox detection (`userPurpose`) | Folder enumeration, mailbox discovery |
 
 ### Principle of Least Privilege
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ The encryption passphrase is **irrecoverable**. If you lose it, all backup data 
 # back up a single mailbox
 atlas outlook backup --mailbox user@company.com
 
-# back up all licensed mailboxes in the tenant
+# back up all licensed and shared mailboxes in the tenant
 atlas outlook backup
 ```
 

--- a/docs/operations/storage-layout.md
+++ b/docs/operations/storage-layout.md
@@ -50,6 +50,8 @@ For managed service providers backing up multiple tenants, this isolation means 
 | `attachments/{mailbox}/` | Encrypted attachments, addressed by SHA-256 | Content is encrypted; S3 metadata is not |
 | `manifests/{mailbox}/` | Encrypted snapshot manifests (JSON) | Contains subjects, folder names, delta URLs -- all encrypted |
 
+Each Outlook manifest records an optional `mailbox_purpose` field -- the Graph `mailboxSettings.userPurpose` value (`user`, `shared`, `room`, ...) at backup time. This makes shared mailboxes auditable: they are typically unlicensed and therefore invisible to license-based inventories, but the manifest flag identifies them in the backup catalog. Converting a user mailbox to a shared mailbox keeps its Entra object ID, so the `manifests/{mailbox}/` prefix stays stable across the conversion: manifests written before the conversion read `user`, later ones read `shared`, and content blobs under `data/{mailbox}/` (addressed by SHA-256) are shared across both -- message data is stored once. Manifests written before this field existed simply omit it.
+
 ### OneDrive
 
 | Prefix | Contents | Security Notes |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,7 +18,7 @@ Outlook mailbox backup, restore, and management commands. All mailbox operations
 
 ### `atlas outlook backup`
 
-Back up mailboxes from an M365 tenant to object storage. When a mailbox is specified with `-m`, backs up that single mailbox with a per-folder progress dashboard. When no mailbox is specified, discovers all Exchange-licensed mailboxes in the tenant and backs them up in parallel.
+Back up mailboxes from an M365 tenant to object storage. When a mailbox is specified with `-m`, backs up that single mailbox with a per-folder progress dashboard. When no mailbox is specified, discovers all Exchange-licensed and shared mailboxes in the tenant and backs them up in parallel.
 
 **Single mailbox:**
 
@@ -32,17 +32,17 @@ atlas outlook backup -m user@company.com --retention-days 365 --lock-mode compli
 atlas outlook backup -t <tenant-id> -m user@company.com        # explicit tenant
 ```
 
-**Full tenant (all licensed mailboxes):**
+**Full tenant (all licensed and shared mailboxes):**
 
 ```bash
-atlas outlook backup                                           # back up all licensed mailboxes (4 concurrent)
+atlas outlook backup                                           # back up all licensed and shared mailboxes (4 concurrent)
 atlas outlook backup -C 8                                      # increase parallel workers to 8
 atlas outlook backup --full                                    # force full sync for all mailboxes
 ```
 
 | Option                   | Description                                                    |
 | ------------------------ | -------------------------------------------------------------- |
-| `-m, --mailbox <id>`     | Specific mailbox to back up (backs up all licensed if omitted) |
+| `-m, --mailbox <id>`     | Specific mailbox to back up (backs up all licensed and shared if omitted) |
 | `-f, --folder <name...>` | Filter to specific folder(s) by display name                   |
 | `--full`                 | Ignore saved delta links, run full enumeration                 |
 | `-P, --page-size <n>`    | Graph API page size per delta request (1--100, default 10)     |
@@ -53,7 +53,7 @@ atlas outlook backup --full                                    # force full sync
 | `-t, --tenant <id>`      | Override tenant ID from config                                 |
 
 ::: tip Tenant-wide mode
-When no `-m` flag is given, Atlas discovers all Exchange Online-licensed mailboxes via Microsoft Graph, then runs up to `-C` concurrent backup workers. A compact dashboard shows each active worker's mailbox, folder progress, and overall completion. The first Ctrl+C gracefully finishes active mailboxes; a second Ctrl+C force-quits immediately.
+When no `-m` flag is given, Atlas discovers all Exchange Online-licensed and shared mailboxes via Microsoft Graph, then runs up to `-C` concurrent backup workers. Shared mailboxes are detected via the Graph `mailboxSettings.userPurpose` property; unlicensed users that are not shared mailboxes are skipped because Graph rejects their mail endpoints. A compact dashboard shows each active worker's mailbox, folder progress, and overall completion. The first Ctrl+C gracefully finishes active mailboxes; a second Ctrl+C force-quits immediately. Failures are isolated per mailbox -- one failing mailbox never aborts the others -- but the command exits non-zero when any mailbox failed, so schedulers and monitoring can detect partial backups instead of treating them as clean runs.
 :::
 
 ::: details Page size tuning
@@ -126,7 +126,7 @@ Restored messages retain their original received/sent timestamps, appear as rece
 
 ### `atlas outlook list`
 
-Browse backed-up data at three zoom levels. Subjects are hidden by default for data protection.
+Browse backed-up data at three zoom levels. Subjects are hidden by default for data protection. The mailbox overview includes a `Type` column sourced from each mailbox's newest manifest that recorded a purpose (`user`, `shared`, `room`, ...; `--` when never recorded).
 
 ```bash
 atlas outlook list                              # all mailboxes with summary stats
@@ -277,7 +277,7 @@ Example output:
 
 ### `atlas outlook mailboxes`
 
-List tenant mailboxes directly from Microsoft Graph (live data, not from the backup catalog). Shows email address, display name, Exchange Online license status, account status, creation date, and optionally mailbox size.
+List tenant mailboxes directly from Microsoft Graph (live data, not from the backup catalog). Shows email address, display name, Exchange Online license status, account status, mailbox type, creation date, and optionally mailbox size.
 
 ```bash
 atlas outlook mailboxes
@@ -287,11 +287,13 @@ atlas outlook mailboxes -t <tenant-id>
 
 | Option              | Description                                                |
 | ------------------- | ---------------------------------------------------------- |
-| `--licensed-only`   | Only show mailboxes with an active Exchange Online license |
+| `--licensed-only`   | Only show mailboxes with an active Exchange Online license (excludes shared mailboxes) |
 | `-t, --tenant <id>` | Override tenant ID from config                             |
 
 ::: tip
 Mailbox size requires the `Reports.Read.All` Graph API permission. If the permission is not granted, the Size column is omitted without error.
+
+The `Type` column shows the Graph `mailboxSettings.userPurpose` value (`user`, `shared`, `room`, `equipment`, ...). To keep discovery fast, it is only resolved for unlicensed mailboxes; `--` means the purpose was not resolved. Note that `--licensed-only` excludes shared mailboxes, which are typically unlicensed.
 :::
 
 ## `atlas onedrive`

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -387,12 +387,16 @@ import { createAtlasInstance } from '@wisecom/atlas-sdk';
 
 const atlas = createAtlasInstance({ /* config */ });
 
-// Discover all licensed mailboxes in the tenant
-const mailboxes = await atlas.outlook.listAvailableMailboxes({ licensed_only: true });
+// Discover all tenant mailboxes (licensed users + shared mailboxes)
+const mailboxes = await atlas.outlook.listAvailableMailboxes();
 
-console.log(`Found ${mailboxes.length} licensed mailboxes:`);
+console.log(`Found ${mailboxes.length} mailboxes:`);
 for (const mb of mailboxes) {
-  console.log(`  ${mb.mail} — ${mb.display_name} (${mb.account_enabled ? 'active' : 'disabled'})`);
+  if (mb.mailbox_purpose === 'shared') {
+    console.log(`  ${mb.mail} — ${mb.display_name} (shared mailbox)`);
+  } else {
+    console.log(`  ${mb.mail} — ${mb.display_name} (${mb.has_exchange_license ? 'licensed' : 'unlicensed'})`);
+  }
 }
 
 // Resolve a user email to their Entra object ID

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -95,6 +95,21 @@ Method names mirror the CLI structure: `atlas outlook backup` maps to `atlas.out
 
 OneDrive and SharePoint expose parallel methods on `atlas.onedrive` and `atlas.sharepoint` (including workload-specific replication). See [OneDrive Backup](/onedrive-backup) and [SharePoint Backup](/sharepoint-backup) for full SDK examples per workload.
 
+### Shared mailbox identity
+
+Three result types carry an optional `mailbox_purpose` field (`'user' | 'linked' | 'shared' | 'room' | 'equipment' | 'others'`), sourced from the Graph `mailboxSettings.userPurpose` property — `'shared'` identifies a shared mailbox:
+
+- `TenantMailbox.mailbox_purpose` (from `listAvailableMailboxes()`; resolved only for unlicensed mailboxes during discovery)
+- `MailboxSummary.mailbox_purpose` (from `listMailboxes()`; taken from the newest manifest that recorded one, so a transient lookup failure in the latest backup does not blank the field)
+- `Manifest.mailbox_purpose` (from `backup()`, `listSnapshots()`, `getSnapshotDetail()`; recorded at backup time)
+
+The field is absent when the purpose was never resolved (pre-feature manifests, lookup failures):
+
+```typescript
+const mailboxes = await atlas.outlook.listAvailableMailboxes();
+const shared = mailboxes.filter((mb) => mb.mailbox_purpose === 'shared');
+```
+
 ## Save Options
 
 `atlas.outlook.save` and `atlas.outlook.saveMailbox` accept the following options:

--- a/package.json
+++ b/package.json
@@ -41,17 +41,12 @@
     "turbo": "^2.9.18",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1",
+    "typescript-language-server": "^5.3.0",
     "vitepress": "^1.6.4",
     "vitest": "^4.1.9"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": "prettier --write"
-  },
-  "pnpm": {
-    "overrides": {
-      "flatted": "3.4.2",
-      "fast-xml-parser": "5.5.7"
-    }
   },
   "packageManager": "pnpm@10.30.3"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-cli",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "CLI for Atlas — secure Microsoft 365 backup and restore to S3-compatible storage.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",
@@ -19,7 +19,10 @@
   "bin": {
     "atlas": "dist/cli.mjs"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "exports": {
     ".": {
       "import": {

--- a/packages/cli/src/commands/outlook-backup.handler.ts
+++ b/packages/cli/src/commands/outlook-backup.handler.ts
@@ -155,12 +155,17 @@ async function backup_all_mailboxes(
   const concurrency = Math.max(1, parseInt(options.concurrency ?? '4', 10) || 4);
   const page_size = Math.max(1, Math.min(100, parseInt(options.pageSize ?? '10', 10) || 10));
 
-  logger.info(`Backing up all licensed mailboxes (concurrency=${concurrency})`);
+  logger.info(`Backing up all licensed and shared mailboxes (concurrency=${concurrency})`);
 
   const orchestrator = container.get<TenantBackupOrchestrator>(TENANT_ORCHESTRATOR_TOKEN);
-  await run_tenant_backup_with_cli_adapter(orchestrator, tenant_id, {
+  const result = await run_tenant_backup_with_cli_adapter(orchestrator, tenant_id, {
     concurrency,
     force_full: options.full ?? false,
     page_size,
   });
+
+  if (result.failed > 0) {
+    logger.error(`Tenant backup finished with ${result.failed} failed mailbox(es)`);
+    process.exitCode = 1;
+  }
 }

--- a/packages/cli/src/commands/outlook-catalog.handler.ts
+++ b/packages/cli/src/commands/outlook-catalog.handler.ts
@@ -105,6 +105,7 @@ function print_mailbox_table(mailboxes: MailboxSummary[]): void {
   const header =
     '  ' +
     pad_cell('Mailbox', 36) +
+    pad_cell('Type', 10) +
     pad_cell('Snapshots', 12) +
     pad_cell('Objects', 10) +
     pad_cell('Size', 12) +
@@ -116,6 +117,7 @@ function print_mailbox_table(mailboxes: MailboxSummary[]): void {
     console.log(
       '  ' +
         pad_cell(m.owner_id, 36) +
+        pad_cell(m.mailbox_purpose ?? '--', 10) +
         pad_cell(String(m.snapshot_count), 12) +
         pad_cell(String(m.total_objects), 10) +
         pad_cell(format_bytes(m.total_size_bytes), 12) +

--- a/packages/cli/src/commands/outlook-mgmt.handler.ts
+++ b/packages/cli/src/commands/outlook-mgmt.handler.ts
@@ -90,7 +90,10 @@ export async function execute_outlook_mailboxes(
   }
 
   const licensed = mailboxes.filter((m) => m.has_exchange_license).length;
-  logger.info(`${mailboxes.length} mailbox(es) found (${licensed} Exchange-licensed)\n`);
+  const shared = mailboxes.filter((m) => m.mailbox_purpose === 'shared').length;
+  logger.info(
+    `${mailboxes.length} mailbox(es) found (${licensed} Exchange-licensed, ${shared} shared)\n`,
+  );
 
   print_mailbox_table(mailboxes);
 }
@@ -186,6 +189,7 @@ function print_mailbox_table(mailboxes: TenantMailbox[]): void {
     pad_cell('Display Name', 24) +
     pad_cell('Exchange', 10) +
     pad_cell('Status', 10) +
+    pad_cell('Type', 10) +
     (has_sizes ? pad_cell('Size', 12) : '') +
     'Created';
   console.log(header);
@@ -202,6 +206,7 @@ function print_mailbox_table(mailboxes: TenantMailbox[]): void {
         pad_cell(truncate_cell(m.display_name, 22), 24) +
         pad_cell(license_flag, 10) +
         pad_cell(status, 10) +
+        pad_cell(m.mailbox_purpose ?? '--', 10) +
         size +
         created,
     );

--- a/packages/cli/tests/unit/backup-command.test.ts
+++ b/packages/cli/tests/unit/backup-command.test.ts
@@ -1,16 +1,33 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Container } from 'inversify';
 import { Command } from 'commander';
 import { register_outlook_command } from '@/commands/outlook.command';
-import { BACKUP_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import { BACKUP_USE_CASE_TOKEN, TENANT_ORCHESTRATOR_TOKEN } from '@wisecom/atlas-types';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
 
 const mock_run_backup_with_cli_adapter = vi.fn();
+const mock_run_tenant_backup_with_cli_adapter = vi.fn();
 
 vi.mock('@/adapters/backup-operation.adapter', () => ({
   run_backup_with_cli_adapter: (...args: unknown[]): unknown =>
     mock_run_backup_with_cli_adapter(...args),
 }));
+
+vi.mock('@/adapters/tenant-backup-operation.adapter', () => ({
+  run_tenant_backup_with_cli_adapter: (...args: unknown[]): unknown =>
+    mock_run_tenant_backup_with_cli_adapter(...args),
+}));
+
+function make_tenant_result(failed: number): Record<string, unknown> {
+  return {
+    outcomes: [],
+    total_mailboxes: 2,
+    succeeded: 2 - failed,
+    failed,
+    interrupted: false,
+    elapsed_ms: 100,
+  };
+}
 
 describe('outlook backup command immutability options', () => {
   let container: Container;
@@ -73,5 +90,44 @@ describe('outlook backup command immutability options', () => {
     const sync_options = mock_run_backup_with_cli_adapter.mock.calls[0][3];
     expect(sync_options.object_lock_policy.mode).toBe('COMPLIANCE');
     expect(sync_options.object_lock_request.mode).toBe('COMPLIANCE');
+  });
+});
+
+describe('outlook backup command exit code for tenant runs', () => {
+  let container: Container;
+  let program: Command;
+  let exit_code_before: string | number | undefined;
+
+  beforeEach(() => {
+    container = new Container();
+    container.bind(BACKUP_USE_CASE_TOKEN).toConstantValue({ sync_mailbox: vi.fn() });
+    container.bind(TENANT_ORCHESTRATOR_TOKEN).toConstantValue({ backup_tenant: vi.fn() });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-from-config' });
+
+    program = new Command();
+    register_outlook_command(program, () => container);
+    mock_run_tenant_backup_with_cli_adapter.mockReset();
+    exit_code_before = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = exit_code_before;
+  });
+
+  it('sets a failing exit code when any mailbox backup failed', async () => {
+    mock_run_tenant_backup_with_cli_adapter.mockResolvedValue(make_tenant_result(1));
+
+    await program.parseAsync(['outlook', 'backup'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('keeps a clean exit code when all mailbox backups succeed', async () => {
+    mock_run_tenant_backup_with_cli_adapter.mockResolvedValue(make_tenant_result(0));
+
+    await program.parseAsync(['outlook', 'backup'], { from: 'user' });
+
+    expect(process.exitCode).toBeUndefined();
   });
 });

--- a/packages/cli/tests/unit/mailboxes-command.test.ts
+++ b/packages/cli/tests/unit/mailboxes-command.test.ts
@@ -5,15 +5,16 @@ import 'reflect-metadata';
 import { register_outlook_command } from '@/commands/outlook.command';
 import { MAILBOX_DISCOVERY_TOKEN } from '@wisecom/atlas-types';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type { MailboxDiscoveryService, TenantMailbox } from '@wisecom/atlas-types';
+import type { MailboxDiscoveryService, MailboxPurpose, TenantMailbox } from '@wisecom/atlas-types';
 
-function make_mailbox(mail: string, licensed = true): TenantMailbox {
+function make_mailbox(mail: string, licensed = true, purpose?: MailboxPurpose): TenantMailbox {
   return {
     user_id: `uid-${mail}`,
     mail,
     display_name: mail.split('@')[0]!,
     has_exchange_license: licensed,
     exchange_plan_status: licensed ? 'Enabled' : undefined,
+    ...(purpose ? { mailbox_purpose: purpose } : {}),
   };
 }
 
@@ -60,6 +61,20 @@ describe('register_outlook_command mailboxes subcommand', () => {
     expect(mock_discovery.list_tenant_mailboxes).toHaveBeenCalledWith('test-tenant', {
       licensed_only: true,
     });
+    log_spy.mockRestore();
+  });
+
+  it('reports the shared mailbox count in the summary line', async () => {
+    vi.mocked(mock_discovery.list_tenant_mailboxes).mockResolvedValue([
+      make_mailbox('alice@t.com'),
+      make_mailbox('team@t.com', false, 'shared'),
+    ]);
+    const log_spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await program.parseAsync(['outlook', 'mailboxes'], { from: 'user' });
+
+    const logged = log_spy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).toContain('2 mailbox(es) found (1 Exchange-licensed, 1 shared)');
     log_spy.mockRestore();
   });
 });

--- a/packages/core/src/services/catalog/catalog.service.ts
+++ b/packages/core/src/services/catalog/catalog.service.ts
@@ -106,6 +106,8 @@ function group_by_mailbox(manifests: Manifest[]): Map<string, Manifest[]> {
  * Builds one MailboxSummary per group. Uses the latest manifest for
  * object count and date, and sums total_size_bytes across all snapshots
  * since each incremental snapshot only contains newly arrived data.
+ * mailbox_purpose comes from the newest manifest that recorded one, so a
+ * transient lookup failure in the latest backup does not blank the type.
  */
 function build_mailbox_summaries(groups: Map<string, Manifest[]>): MailboxSummary[] {
   const summaries: MailboxSummary[] = [];
@@ -113,10 +115,12 @@ function build_mailbox_summaries(groups: Map<string, Manifest[]>): MailboxSummar
   for (const [owner_id, manifests] of groups) {
     manifests.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
     const latest = manifests[0]!;
+    const purpose = manifests.find((m) => m.mailbox_purpose)?.mailbox_purpose;
     const cumulative_size = manifests.reduce((sum, m) => sum + m.total_size_bytes, 0);
 
     summaries.push({
       owner_id,
+      ...(purpose ? { mailbox_purpose: purpose } : {}),
       snapshot_count: manifests.length,
       total_objects: latest.total_objects,
       total_size_bytes: cumulative_size,

--- a/packages/core/tests/unit/services/catalog.service.test.ts
+++ b/packages/core/tests/unit/services/catalog.service.test.ts
@@ -142,6 +142,53 @@ describe('CatalogService', () => {
       expect(bob.total_objects).toBe(5);
     });
 
+    it('reports mailbox_purpose from the latest manifest after conversion', async () => {
+      vi.mocked(mock_manifests.list_all_manifests).mockResolvedValue([
+        make_manifest({
+          owner_id: 'converted@test.com',
+          snapshot_id: 's1',
+          created_at: new Date('2026-03-01'),
+          mailbox_purpose: 'user',
+        }),
+        make_manifest({
+          owner_id: 'converted@test.com',
+          snapshot_id: 's2',
+          created_at: new Date('2026-03-05'),
+          mailbox_purpose: 'shared',
+        }),
+        make_manifest({ owner_id: 'legacy@test.com', snapshot_id: 's3' }),
+      ]);
+
+      const result = await service.list_mailboxes('t');
+
+      const converted = result.find((m) => m.owner_id === 'converted@test.com')!;
+      expect(converted.mailbox_purpose).toBe('shared');
+
+      const legacy = result.find((m) => m.owner_id === 'legacy@test.com')!;
+      expect('mailbox_purpose' in legacy).toBe(false);
+    });
+
+    it('falls back to the newest manifest that recorded a purpose when the latest lacks one', async () => {
+      vi.mocked(mock_manifests.list_all_manifests).mockResolvedValue([
+        make_manifest({
+          owner_id: 'team@test.com',
+          snapshot_id: 's1',
+          created_at: new Date('2026-03-01'),
+          mailbox_purpose: 'shared',
+        }),
+        // Latest backup's purpose lookup failed -- field absent.
+        make_manifest({
+          owner_id: 'team@test.com',
+          snapshot_id: 's2',
+          created_at: new Date('2026-03-05'),
+        }),
+      ]);
+
+      const result = await service.list_mailboxes('t');
+
+      expect(result[0]!.mailbox_purpose).toBe('shared');
+    });
+
     it('returns summaries sorted alphabetically by owner_id', async () => {
       vi.mocked(mock_manifests.list_all_manifests).mockResolvedValue([
         make_manifest({ owner_id: 'zara@test.com', snapshot_id: 's1' }),

--- a/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
+++ b/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
@@ -18,6 +18,7 @@ import type {
   DeltaPageCallback,
   MessageAttachment,
 } from '@wisecom/atlas-types/ports/mail/connector.port';
+import type { MailboxPurpose } from '@wisecom/atlas-types/domain/manifest';
 import type {
   MailboxRateLimiter,
   MailboxRateLimiterFactory,
@@ -58,6 +59,20 @@ export class RateLimitedGraphConnector implements MailboxConnector {
         resource_units: GRAPH_SERVICE_LIMITS.identity.user_get_cost,
       });
       return this._inner.mailbox_exists(tenant_id, owner_id);
+    });
+  }
+
+  async get_mailbox_purpose(
+    tenant_id: string,
+    owner_id: string,
+  ): Promise<MailboxPurpose | undefined> {
+    if (!this._inner.get_mailbox_purpose) return undefined;
+    // GET /users/{id}/mailboxSettings -- Identity pool
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () => {
+      get_active_counter()?.record('identity', 'get_mailbox_purpose', {
+        resource_units: GRAPH_SERVICE_LIMITS.identity.user_get_cost,
+      });
+      return this._inner.get_mailbox_purpose!(tenant_id, owner_id);
     });
   }
 

--- a/packages/outlook/src/adapters/graph-delta-message-mapper.ts
+++ b/packages/outlook/src/adapters/graph-delta-message-mapper.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure mapping helpers for Graph delta-sync responses: the field selection
+ * list, response shapes, and conversion of raw Graph messages into MailMessage.
+ */
+
+import type { MailMessage } from '@wisecom/atlas-types';
+import type { GraphUserRecord, GraphFolderRecord } from '@/adapters/graph-mailbox-response-mappers';
+
+/**
+ * Fields to request from the delta endpoint so each page contains
+ * the full message body, eliminating the need for per-message fetches.
+ */
+export const DELTA_SELECT_FIELDS = [
+  'id',
+  'subject',
+  'body',
+  'bodyPreview',
+  'from',
+  'sender',
+  'toRecipients',
+  'ccRecipients',
+  'bccRecipients',
+  'replyTo',
+  'receivedDateTime',
+  'sentDateTime',
+  'createdDateTime',
+  'lastModifiedDateTime',
+  'parentFolderId',
+  'importance',
+  'isRead',
+  'isDraft',
+  'hasAttachments',
+  'internetMessageId',
+  'conversationId',
+  'flag',
+  'categories',
+].join(',');
+
+export interface GraphPageResponse {
+  value?: GraphUserRecord[] | GraphFolderRecord[] | GraphDeltaMessage[];
+  '@odata.nextLink'?: string;
+  '@odata.deltaLink'?: string;
+}
+
+export interface GraphDeltaMessage {
+  id?: string;
+  subject?: string;
+  body?: { contentType?: string; content?: string };
+  hasAttachments?: boolean;
+  receivedDateTime?: string;
+  parentFolderId?: string;
+  '@removed'?: { reason: string };
+  [key: string]: unknown;
+}
+
+/** Converts a raw Graph message response into our MailMessage domain type. */
+export function graph_message_to_mail_message(msg: GraphDeltaMessage): MailMessage {
+  const body_buffer = Buffer.from(JSON.stringify(msg));
+  return {
+    message_id: msg.id ?? '',
+    folder_id: (msg.parentFolderId as string) ?? '',
+    subject: (msg.subject as string) ?? '',
+    received_at: msg.receivedDateTime ? new Date(msg.receivedDateTime) : new Date(),
+    size_bytes: body_buffer.length,
+    raw_body: body_buffer,
+    has_attachments: msg.hasAttachments === true,
+  };
+}
+
+/** Separates delta page items into live messages and removed message IDs. */
+export function extract_page_messages(
+  items: GraphDeltaMessage[],
+  removed_ids: string[],
+): MailMessage[] {
+  const page_messages: MailMessage[] = [];
+  for (const item of items) {
+    if (item['@removed'] && item.id) {
+      removed_ids.push(item.id);
+    } else if (item.id) {
+      page_messages.push(graph_message_to_mail_message(item));
+    }
+  }
+  return page_messages;
+}

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -3,6 +3,7 @@ import type { Client } from '@microsoft/microsoft-graph-client';
 import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
 import type {
   MailboxConnector,
+  MailboxPurpose,
   MailFolder,
   MailMessage,
   MessageAttachment,
@@ -25,54 +26,14 @@ import {
   extract_user_ids,
   filter_and_map_folders,
   map_file_attachments,
+  parse_mailbox_purpose,
 } from '@/adapters/graph-mailbox-response-mappers';
-
-/**
- * Fields to request from the delta endpoint so each page contains
- * the full message body, eliminating the need for per-message fetches.
- */
-const DELTA_SELECT_FIELDS = [
-  'id',
-  'subject',
-  'body',
-  'bodyPreview',
-  'from',
-  'sender',
-  'toRecipients',
-  'ccRecipients',
-  'bccRecipients',
-  'replyTo',
-  'receivedDateTime',
-  'sentDateTime',
-  'createdDateTime',
-  'lastModifiedDateTime',
-  'parentFolderId',
-  'importance',
-  'isRead',
-  'isDraft',
-  'hasAttachments',
-  'internetMessageId',
-  'conversationId',
-  'flag',
-  'categories',
-].join(',');
-
-interface GraphPageResponse {
-  value?: GraphUserRecord[] | GraphFolderRecord[] | GraphDeltaMessage[];
-  '@odata.nextLink'?: string;
-  '@odata.deltaLink'?: string;
-}
-
-interface GraphDeltaMessage {
-  id?: string;
-  subject?: string;
-  body?: { contentType?: string; content?: string };
-  hasAttachments?: boolean;
-  receivedDateTime?: string;
-  parentFolderId?: string;
-  '@removed'?: { reason: string };
-  [key: string]: unknown;
-}
+import type { GraphPageResponse, GraphDeltaMessage } from '@/adapters/graph-delta-message-mapper';
+import {
+  DELTA_SELECT_FIELDS,
+  extract_page_messages,
+  graph_message_to_mail_message,
+} from '@/adapters/graph-delta-message-mapper';
 
 @injectable()
 export class GraphMailboxConnector implements MailboxConnector {
@@ -104,6 +65,23 @@ export class GraphMailboxConnector implements MailboxConnector {
       if ((err as Record<string, unknown>).statusCode === 404) return false;
       rethrow_if_access_denied(err);
       throw err;
+    }
+  }
+
+  /** Resolves userPurpose from mailboxSettings; returns undefined on any error (metadata must never fail a backup). */
+  async get_mailbox_purpose(
+    _tenant_id: string,
+    owner_id: string,
+  ): Promise<MailboxPurpose | undefined> {
+    try {
+      const res = await with_graph_retry(() =>
+        this._client.api(`/users/${owner_id}/mailboxSettings?$select=userPurpose`).get(),
+      );
+      return parse_mailbox_purpose((res as { userPurpose?: unknown } | undefined)?.userPurpose);
+    } catch (err) {
+      // ponytail: swallow-all — 403/404 on some shared/resource mailboxes is a known Graph quirk
+      logger.debug(`mailboxSettings lookup failed for ${owner_id}: ${(err as Error).message}`);
+      return undefined;
     }
   }
 
@@ -181,7 +159,7 @@ export class GraphMailboxConnector implements MailboxConnector {
             .get() as Promise<GraphDeltaMessage>,
       );
 
-      return this.graph_message_to_mail_message(response);
+      return graph_message_to_mail_message(response);
     } catch (err) {
       rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
@@ -286,7 +264,7 @@ export class GraphMailboxConnector implements MailboxConnector {
     while (true) {
       page_count++;
       const items = (page.value ?? []) as GraphDeltaMessage[];
-      const page_messages = this.extract_page_messages(items, removed_ids);
+      const page_messages = extract_page_messages(items, removed_ids);
 
       const callback_result = await this.handle_page_callback(
         on_page,
@@ -312,19 +290,6 @@ export class GraphMailboxConnector implements MailboxConnector {
     return { messages, removed_ids, delta_link, delta_reset };
   }
 
-  /** Separates delta page items into live messages and removed message IDs. */
-  private extract_page_messages(items: GraphDeltaMessage[], removed_ids: string[]): MailMessage[] {
-    const page_messages: MailMessage[] = [];
-    for (const item of items) {
-      if (item['@removed'] && item.id) {
-        removed_ids.push(item.id);
-      } else if (item.id) {
-        page_messages.push(this.graph_message_to_mail_message(item));
-      }
-    }
-    return page_messages;
-  }
-
   /** Invokes the page callback or accumulates messages; returns continuation flag. */
   private async handle_page_callback(
     on_page: DeltaPageCallback | undefined,
@@ -342,20 +307,6 @@ export class GraphMailboxConnector implements MailboxConnector {
     const cb_result = on_page(page_count, new_total_streamed, page_messages);
     const should_continue = cb_result instanceof Promise ? await cb_result : cb_result;
     return { should_continue, new_total_streamed };
-  }
-
-  /** Converts a raw Graph message response into our MailMessage domain type. */
-  private graph_message_to_mail_message(msg: GraphDeltaMessage): MailMessage {
-    const body_buffer = Buffer.from(JSON.stringify(msg));
-    return {
-      message_id: msg.id ?? '',
-      folder_id: (msg.parentFolderId as string) ?? '',
-      subject: (msg.subject as string) ?? '',
-      received_at: msg.receivedDateTime ? new Date(msg.receivedDateTime) : new Date(),
-      size_bytes: body_buffer.length,
-      raw_body: body_buffer,
-      has_attachments: msg.hasAttachments === true,
-    };
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/outlook/src/adapters/graph-mailbox-discovery.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-discovery.adapter.ts
@@ -1,6 +1,7 @@
 /**
  * Graph API adapter for discovering tenant mailboxes with Exchange license information.
  * Queries /users with assignedPlans to detect Exchange Online licensing,
+ * resolves mailboxSettings.userPurpose for unlicensed mailboxes (shared-mailbox detection),
  * and enriches with mailbox size from the usage reports API when available.
  */
 
@@ -10,10 +11,14 @@ import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
 import type {
   MailboxDiscoveryService,
   MailboxDiscoveryOptions,
+  MailboxPurpose,
   TenantMailbox,
 } from '@wisecom/atlas-types';
 import type { GraphUserRecord } from '@/adapters/graph-mailbox-response-mappers';
-import { map_users_to_tenant_mailboxes } from '@/adapters/graph-mailbox-response-mappers';
+import {
+  map_users_to_tenant_mailboxes,
+  parse_mailbox_purpose,
+} from '@/adapters/graph-mailbox-response-mappers';
 import { rethrow_if_access_denied, with_graph_retry } from '@wisecom/atlas-m365-graph';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -49,6 +54,16 @@ export class GraphMailboxDiscoveryAdapter implements MailboxDiscoveryService {
         mailboxes = mailboxes.filter((m) => m.has_exchange_license);
       }
 
+      // ponytail: purpose fetched for unlicensed only; per-user N+1 at concurrency 5 — switch to Graph $batch if unlicensed counts make discovery slow
+      const unlicensed_ids = mailboxes.filter((m) => !m.has_exchange_license).map((m) => m.user_id);
+      const purposes = await this.fetchPurposes(unlicensed_ids);
+      if (purposes.size > 0) {
+        mailboxes = mailboxes.map((m) => {
+          const p = purposes.get(m.user_id);
+          return p ? { ...m, mailbox_purpose: p } : m;
+        });
+      }
+
       const usage = await this.fetchMailboxUsage();
       if (usage.size > 0) {
         mailboxes = mailboxes.map((m) => {
@@ -82,6 +97,39 @@ export class GraphMailboxDiscoveryAdapter implements MailboxDiscoveryService {
     }
 
     return all;
+  }
+
+  /** Resolves mailboxSettings.userPurpose per user at bounded concurrency; failed lookups are logged and skipped. */
+  private async fetchPurposes(user_ids: string[]): Promise<Map<string, MailboxPurpose>> {
+    const CONCURRENCY = 5;
+    const purposes = new Map<string, MailboxPurpose>();
+    const queue = [...user_ids];
+
+    const worker = async (): Promise<void> => {
+      while (queue.length > 0) {
+        const user_id = queue.shift()!;
+        try {
+          const res = await with_graph_retry(() =>
+            this._client.api(`/users/${user_id}/mailboxSettings?$select=userPurpose`).get(),
+          );
+          const purpose = parse_mailbox_purpose(
+            (res as { userPurpose?: unknown } | undefined)?.userPurpose,
+          );
+          if (purpose) purposes.set(user_id, purpose);
+        } catch (err) {
+          // Purpose is optional metadata; a 403/404 here must never fail discovery.
+          // But an undetected shared mailbox is silently excluded from tenant backup, so make it visible.
+          logger.warn(
+            `Could not resolve mailbox purpose for ${user_id}; ` +
+              `if this is a shared mailbox it will be skipped by tenant backup (${(err as Error).message})`,
+          );
+        }
+      }
+    };
+
+    const workers = Array.from({ length: Math.min(CONCURRENCY, user_ids.length) }, () => worker());
+    await Promise.all(workers);
+    return purposes;
   }
 
   /** Fetches the mailbox usage report CSV. Returns empty map if Reports.Read.All is missing. */

--- a/packages/outlook/src/adapters/graph-mailbox-response-mappers.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-response-mappers.ts
@@ -1,4 +1,4 @@
-import type { MailFolder, MessageAttachment } from '@wisecom/atlas-types';
+import type { MailboxPurpose, MailFolder, MessageAttachment } from '@wisecom/atlas-types';
 import type { TenantMailbox } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -40,6 +40,23 @@ export interface GraphAttachmentRecord {
 /** Extracts non-null user IDs from Graph user records. */
 export function extract_user_ids(users: GraphUserRecord[]): string[] {
   return users.filter((u) => u.id).map((u) => u.id!);
+}
+
+const KNOWN_PURPOSES: readonly MailboxPurpose[] = [
+  'user',
+  'linked',
+  'shared',
+  'room',
+  'equipment',
+  'others',
+];
+
+/** Normalizes a Graph userPurpose value; unknown strings (e.g. unknownFutureValue) map to 'others'. */
+export function parse_mailbox_purpose(value: unknown): MailboxPurpose | undefined {
+  if (typeof value !== 'string' || value === '') return undefined;
+  return (KNOWN_PURPOSES as readonly string[]).includes(value)
+    ? (value as MailboxPurpose)
+    : 'others';
 }
 
 /** Filters out excluded system folders and maps to our MailFolder type. */

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -56,6 +56,7 @@ export class MailboxSyncService implements BackupUseCase {
   ): Promise<SyncResult> {
     owner_id = owner_id.toLowerCase();
     await assert_mailbox_exists(this._connector, tenant_id, owner_id);
+    const mailbox_purpose = await this._connector.get_mailbox_purpose?.(tenant_id, owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       await this.warn_if_replica(ctx);
@@ -150,6 +151,7 @@ export class MailboxSyncService implements BackupUseCase {
         merged_links,
         previous_entry_count,
         this.build_manifest_object_lock_policy(options),
+        mailbox_purpose,
       );
       await this._manifests.save(ctx, manifest);
 

--- a/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
+++ b/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import type { Snapshot } from '@wisecom/atlas-types';
 import { SnapshotStatus } from '@wisecom/atlas-types';
-import type { Manifest, ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-types';
+import type {
+  MailboxPurpose,
+  Manifest,
+  ManifestEntry,
+  ManifestObjectLockPolicy,
+} from '@wisecom/atlas-types';
 
 export interface OwnerIdentityHint {
   readonly owner_email?: string | undefined;
@@ -42,6 +47,7 @@ export function mark_snapshot_completed(snapshot: Snapshot, object_count: number
  * Assembles a complete manifest. When the current sync found no new entries,
  * carries forward the prior backup's total_objects so the stale-delta
  * safeguard does not mistake an unchanged mailbox for a never-backed-up one.
+ * mailbox_purpose (Graph userPurpose at backup time) is recorded when known.
  */
 export function build_manifest(
   owner_id: string,
@@ -50,6 +56,7 @@ export function build_manifest(
   delta_links: Record<string, string>,
   previous_total_objects = 0,
   object_lock?: ManifestObjectLockPolicy,
+  mailbox_purpose?: MailboxPurpose,
 ): Manifest {
   const total_size_bytes = entries.reduce((sum, e) => {
     const att_size = e.attachments?.reduce((a, att) => a + att.size_bytes, 0) ?? 0;
@@ -65,6 +72,7 @@ export function build_manifest(
     total_size_bytes,
     delta_links,
     ...(object_lock ? { object_lock } : {}),
+    ...(mailbox_purpose ? { mailbox_purpose } : {}),
     entries,
   };
 }

--- a/packages/outlook/src/services/backup/tenant-backup-orchestrator.ts
+++ b/packages/outlook/src/services/backup/tenant-backup-orchestrator.ts
@@ -1,6 +1,7 @@
 /**
- * Orchestrates parallel backup of all licensed mailboxes in a tenant.
- * Always filters to Exchange-licensed mailboxes -- unlicensed ones cause Graph errors.
+ * Orchestrates parallel backup of all licensed and shared mailboxes in a tenant.
+ * Unlicensed non-shared users are skipped -- Graph rejects their mail endpoints.
+ * Shared mailboxes are detected via mailboxSettings.userPurpose during discovery.
  * CLI-only -- not wired into the SDK adapter.
  */
 
@@ -39,11 +40,14 @@ export class DefaultTenantBackupOrchestrator implements ITenantBackupOrchestrato
     const should_force_stop = options.should_force_stop ?? always_false;
     const progress = options.progress;
 
-    const mailboxes = await this._discovery.list_tenant_mailboxes(tenant_id, {
-      licensed_only: true,
-    });
+    const all = await this._discovery.list_tenant_mailboxes(tenant_id);
+    const mailboxes = all.filter((m) => m.has_exchange_license || m.mailbox_purpose === 'shared');
+    const shared_count = mailboxes.filter((m) => m.mailbox_purpose === 'shared').length;
+    const skipped_count = all.length - mailboxes.length;
 
-    logger.info(`Discovered ${mailboxes.length} mailbox(es) for backup`);
+    logger.info(
+      `Discovered ${mailboxes.length} mailbox(es) for backup (${shared_count} shared, ${skipped_count} unlicensed non-shared skipped)`,
+    );
     progress?.set_mailbox_count(mailboxes.length);
 
     const outcomes: MailboxBackupOutcome[] = [];

--- a/packages/outlook/tests/unit/mailbox-discovery.test.ts
+++ b/packages/outlook/tests/unit/mailbox-discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   extract_exchange_license_status,
   map_users_to_tenant_mailboxes,
+  parse_mailbox_purpose,
 } from '@/adapters/graph-mailbox-response-mappers';
 import { parse_usage_csv } from '@/adapters/graph-mailbox-discovery.adapter';
 import type { GraphAssignedPlan, GraphUserRecord } from '@/adapters/graph-mailbox-response-mappers';
@@ -43,6 +44,24 @@ describe('extract_exchange_license_status', () => {
       { service: 'SharePoint', capabilityStatus: 'Enabled', servicePlanId: 'abc' },
     ];
     expect(extract_exchange_license_status(plans)).toEqual({ has_license: false });
+  });
+});
+
+describe('parse_mailbox_purpose', () => {
+  it('passes through known purposes', () => {
+    expect(parse_mailbox_purpose('shared')).toBe('shared');
+    expect(parse_mailbox_purpose('user')).toBe('user');
+    expect(parse_mailbox_purpose('room')).toBe('room');
+  });
+
+  it('maps unknown strings to others', () => {
+    expect(parse_mailbox_purpose('unknownFutureValue')).toBe('others');
+  });
+
+  it('returns undefined for empty or non-string values', () => {
+    expect(parse_mailbox_purpose(undefined)).toBeUndefined();
+    expect(parse_mailbox_purpose('')).toBeUndefined();
+    expect(parse_mailbox_purpose(42)).toBeUndefined();
   });
 });
 

--- a/packages/outlook/tests/unit/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync.service.test.ts
@@ -142,6 +142,22 @@ describe('MailboxSyncService', () => {
     expect(mock_connector.list_mail_folders).toHaveBeenCalledWith('t', 'user@test.com');
   });
 
+  it('records mailbox_purpose in the manifest when the connector reports it', async () => {
+    mock_connector.get_mailbox_purpose = vi.fn().mockResolvedValue('shared');
+
+    await service.sync_mailbox('t', 'shared@test.com');
+
+    const [, manifest] = vi.mocked(mock_manifests.save).mock.calls[0]!;
+    expect(manifest.mailbox_purpose).toBe('shared');
+  });
+
+  it('omits mailbox_purpose when the connector does not implement the lookup', async () => {
+    await service.sync_mailbox('t', 'user@test.com');
+
+    const [, manifest] = vi.mocked(mock_manifests.save).mock.calls[0]!;
+    expect('mailbox_purpose' in manifest).toBe(false);
+  });
+
   it('fetches delta for each folder', async () => {
     vi.mocked(mock_connector.list_mail_folders).mockResolvedValue([
       make_folder('Inbox', 'f1'),

--- a/packages/outlook/tests/unit/tenant-backup-orchestrator.test.ts
+++ b/packages/outlook/tests/unit/tenant-backup-orchestrator.test.ts
@@ -4,14 +4,20 @@ import 'reflect-metadata';
 import { DefaultTenantBackupOrchestrator } from '@/services/backup/tenant-backup-orchestrator';
 import { MAILBOX_DISCOVERY_TOKEN } from '@wisecom/atlas-types';
 import { BACKUP_USE_CASE_TOKEN } from '@wisecom/atlas-types';
-import type { MailboxDiscoveryService, TenantMailbox } from '@wisecom/atlas-types';
+import type { MailboxDiscoveryService, MailboxPurpose, TenantMailbox } from '@wisecom/atlas-types';
 import type { BackupUseCase, SyncResult, BackupSyncSummary } from '@wisecom/atlas-types';
 import type { Manifest } from '@wisecom/atlas-types';
 import type { Snapshot } from '@wisecom/atlas-types';
 import { SnapshotStatus } from '@wisecom/atlas-types';
 
-function make_mailbox(mail: string, licensed = true): TenantMailbox {
-  return { user_id: `uid-${mail}`, mail, display_name: mail, has_exchange_license: licensed };
+function make_mailbox(mail: string, licensed = true, purpose?: MailboxPurpose): TenantMailbox {
+  return {
+    user_id: `uid-${mail}`,
+    mail,
+    display_name: mail,
+    has_exchange_license: licensed,
+    ...(purpose ? { mailbox_purpose: purpose } : {}),
+  };
 }
 
 function make_sync_result(mailbox_id: string): SyncResult {
@@ -83,13 +89,23 @@ describe('DefaultTenantBackupOrchestrator', () => {
     expect(mock_backup.sync_mailbox).toHaveBeenCalledTimes(3);
   });
 
-  it('always discovers licensed-only mailboxes', async () => {
-    const orch = container.get(DefaultTenantBackupOrchestrator);
-    await orch.backup_tenant('t1');
+  it('includes shared mailboxes and skips plain unlicensed ones', async () => {
+    vi.mocked(mock_discovery.list_tenant_mailboxes).mockResolvedValue([
+      make_mailbox('licensed@t.com', true),
+      make_mailbox('shared@t.com', false, 'shared'),
+      make_mailbox('unlicensed@t.com', false),
+    ]);
 
-    expect(mock_discovery.list_tenant_mailboxes).toHaveBeenCalledWith('t1', {
-      licensed_only: true,
-    });
+    const orch = container.get(DefaultTenantBackupOrchestrator);
+    const result = await orch.backup_tenant('t1');
+
+    expect(mock_discovery.list_tenant_mailboxes).toHaveBeenCalledWith('t1');
+    expect(mock_backup.sync_mailbox).toHaveBeenCalledTimes(2);
+    const backed_up = vi.mocked(mock_backup.sync_mailbox).mock.calls.map((c) => c[1]);
+    expect(backed_up).toContain('licensed@t.com');
+    expect(backed_up).toContain('shared@t.com');
+    expect(backed_up).not.toContain('unlicensed@t.com');
+    expect(result.total_mailboxes).toBe(2);
   });
 
   it('captures errors per mailbox without aborting', async () => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sdk",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Programmatic API for embedding Atlas M365 backup and restore in Node.js applications.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",
@@ -16,7 +16,10 @@
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "exports": {
     ".": {
       "import": {

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -4,6 +4,7 @@ export { SnapshotStatus } from './snapshot';
 export type { BackupObject } from './backup-object';
 export type {
   Manifest,
+  MailboxPurpose,
   ManifestEntry,
   AttachmentEntry,
   ManifestObjectLockMode,

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -1,3 +1,6 @@
+/** Mailbox purpose from Graph mailboxSettings.userPurpose. 'shared' identifies shared mailboxes. */
+export type MailboxPurpose = 'user' | 'linked' | 'shared' | 'room' | 'equipment' | 'others';
+
 export type ManifestObjectLockMode = 'GOVERNANCE' | 'COMPLIANCE';
 
 export interface ManifestObjectLockRequestedPolicy {
@@ -20,6 +23,8 @@ export interface Manifest {
   readonly tenant_id: string;
   /** Entra object ID (UUID) of the mailbox owner; used as the storage partition key. */
   readonly owner_id: string;
+  /** Graph mailboxSettings.userPurpose at backup time; 'shared' = shared mailbox. Absent on pre-feature manifests or when the lookup failed. */
+  readonly mailbox_purpose?: MailboxPurpose;
   readonly snapshot_id: string;
   readonly created_at: Date;
   readonly total_objects: number;

--- a/packages/types/src/ports/catalog/use-case.port.ts
+++ b/packages/types/src/ports/catalog/use-case.port.ts
@@ -1,7 +1,9 @@
-import type { AttachmentEntry, Manifest } from '@/domain/manifest';
+import type { AttachmentEntry, MailboxPurpose, Manifest } from '@/domain/manifest';
 
 export interface MailboxSummary {
   readonly owner_id: string;
+  /** Purpose from the newest manifest that recorded one; 'shared' = shared mailbox. Absent when never recorded. */
+  readonly mailbox_purpose?: MailboxPurpose;
   readonly snapshot_count: number;
   readonly total_objects: number;
   readonly total_size_bytes: number;

--- a/packages/types/src/ports/mail/connector.port.ts
+++ b/packages/types/src/ports/mail/connector.port.ts
@@ -1,3 +1,5 @@
+import type { MailboxPurpose } from '@/domain/manifest';
+
 export interface MailFolder {
   readonly folder_id: string;
   readonly display_name: string;
@@ -50,6 +52,13 @@ export interface MailboxConnector {
 
   /** Returns true if the mailbox exists in the tenant, false otherwise. */
   mailbox_exists(tenant_id: string, owner_id: string): Promise<boolean>;
+
+  /**
+   * Resolves the mailbox purpose (user/shared/...) via mailboxSettings.
+   * Optional: absent or resolving undefined means unknown; callers must treat both the same.
+   */
+  // ponytail: optional method — keeps ~10 existing MailboxConnector test literals compiling; make it required if a second caller ever needs it guaranteed
+  get_mailbox_purpose?(tenant_id: string, owner_id: string): Promise<MailboxPurpose | undefined>;
 
   list_mail_folders(tenant_id: string, owner_id: string): Promise<MailFolder[]>;
 

--- a/packages/types/src/ports/mail/discovery.port.ts
+++ b/packages/types/src/ports/mail/discovery.port.ts
@@ -1,9 +1,13 @@
+import type { MailboxPurpose } from '@/domain/manifest';
+
 export interface TenantMailbox {
   readonly user_id: string;
   readonly mail: string;
   readonly display_name: string;
   readonly has_exchange_license: boolean;
   readonly exchange_plan_status?: string;
+  /** Graph userPurpose; only resolved for unlicensed mailboxes during discovery. */
+  readonly mailbox_purpose?: MailboxPurpose;
   readonly created_at?: Date;
   readonly mailbox_size_bytes?: number;
   readonly item_count?: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript-eslint:
         specifier: ^8.56.1
         version: 8.56.1(eslint@10.0.3)(typescript@5.9.3)
+      typescript-language-server:
+        specifier: ^5.3.0
+        version: 5.3.0
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.49.2)(@types/node@25.3.5)(postcss@8.5.15)(search-insights@2.17.3)(typescript@5.9.3)
@@ -4144,6 +4147,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  typescript-language-server@5.3.0:
+    resolution: {integrity: sha512-5puofxZHgFdAYtfNpmwCAvgtaYgg8wrUnH30m7Ze3QuguId5RNRadKASpOpyDxTyUdAF51FjhTdjntLw/EuWcQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4346,6 +4354,20 @@ packages:
 
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
+
+  vscode-jsonrpc@5.0.1:
+    resolution: {integrity: sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==}
+    engines: {node: '>=8.0.0 || >=10.0.0'}
+
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.18.2:
+    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
   vue@3.5.30:
     resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
@@ -8840,6 +8862,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript-language-server@5.3.0:
+    dependencies:
+      vscode-jsonrpc: 5.0.1
+      vscode-languageserver-protocol: 3.18.2
+
   typescript@5.9.3: {}
 
   umd@3.0.3: {}
@@ -9025,6 +9052,17 @@ snapshots:
       - msw
 
   vm-browserify@1.1.2: {}
+
+  vscode-jsonrpc@5.0.1: {}
+
+  vscode-jsonrpc@9.0.1: {}
+
+  vscode-languageserver-protocol@3.18.2:
+    dependencies:
+      vscode-jsonrpc: 9.0.1
+      vscode-languageserver-types: 3.18.0
+
+  vscode-languageserver-types@3.18.0: {}
 
   vue@3.5.30(typescript@5.9.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,7 @@ packages:
   - 'tools/*'
 
 minimumReleaseAge: 1440
+
+overrides:
+  flatted: 3.4.2
+  fast-xml-parser: 5.5.7


### PR DESCRIPTION
## Summary

- **Shared mailbox backup**: discovery resolves Graph `mailboxSettings.userPurpose` for unlicensed mailboxes; tenant backup now includes licensed **and** shared mailboxes (plain unlicensed users are still skipped -- Graph rejects their mail endpoints)
- **`mailbox_purpose` in manifests**: recorded at backup time, surfaced as a `Type` column in `atlas outlook list` and `atlas outlook mailboxes`; the catalog uses the newest manifest that recorded a purpose so a transient lookup failure does not blank the type
- **Observability**: failed purpose lookups are logged with the skip consequence; the orchestrator logs how many unlicensed non-shared mailboxes it skipped
- **Exit code fix**: `atlas outlook backup` (tenant-wide) now sets `process.exitCode = 1` when any mailbox failed, so schedulers/monitoring detect partial backups
- **Refactor**: delta message mapping extracted into `graph-delta-message-mapper.ts`; pnpm overrides moved to `pnpm-workspace.yaml`
- **Release prep**: `@wisecom/atlas-cli` and `@wisecom/atlas-sdk` bumped to `2.0.0-beta.2`

## Docs

cli.md, sdk.md, examples.md, azure-ad-setup.md, getting-started.md, storage-layout.md updated; `pnpm run docs:build` passes.

## Verification

- 590 tests pass across all 15 packages (new: catalog purpose fallback, tenant exit-code paths, purpose parsing, orchestrator shared-inclusion)
- `pnpm run build` / `lint` clean

Tagging `v2.0.0-beta.2` after merge to trigger the npm publish pipeline.