### PR TITLE
fix(outlook): never persist a delta link past unprocessed messages on interrupt

### DIFF
--- a/packages/outlook/src/services/backup/folder-sync-executor.ts
+++ b/packages/outlook/src/services/backup/folder-sync-executor.ts
@@ -9,6 +9,8 @@ import type { BackupProgressReporter, ObjectLockPolicy } from '@wisecom/atlas-ty
 export interface FolderSyncResult {
   entries: ManifestEntry[];
   delta_link: string;
+  /** True only when every page of the folder was fully processed; the delta link MUST NOT be persisted otherwise. */
+  complete: boolean;
   stored: number;
   deduplicated: number;
   attachments_stored: number;
@@ -127,6 +129,8 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
   const pending_attachments: PendingAttachment[] = [];
   let folder_processed = 0;
   let streamed = false;
+  // Set whenever any page or message is skipped; blocks delta-link persistence (issue #23).
+  let aborted = false;
   const page_start = Date.now();
 
   const on_page = async (
@@ -136,7 +140,10 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
   ): Promise<boolean> => {
     streamed = true;
 
-    if (is_hard_stopped()) return false;
+    if (is_hard_stopped()) {
+      aborted = true;
+      return false;
+    }
 
     const elapsed_ms = Date.now() - page_start;
     const page_rate = calc_rate(total_items, elapsed_ms);
@@ -144,10 +151,16 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
     const eta = page_rate > 0 ? remaining / page_rate : 0;
     progress.update_paging(folder_index, total_items, page_rate, eta);
 
-    if (is_interrupted()) return true;
+    if (is_interrupted()) {
+      aborted = true;
+      return false;
+    }
 
     for (const message of page_messages) {
-      if (is_interrupted()) break;
+      if (is_interrupted()) {
+        aborted = true;
+        break;
+      }
       await process_message(
         ctx,
         connector,
@@ -178,7 +191,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       object_lock_policy,
     );
 
-    return true;
+    return !aborted;
   };
 
   let delta = await connector.fetch_delta(
@@ -191,7 +204,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
   );
 
   if (
-    !is_interrupted() &&
+    !aborted &&
     prev_delta_link &&
     folder_processed === 0 &&
     folder_total > 0 &&
@@ -209,7 +222,10 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
 
   if (!streamed) {
     for (const message of delta.messages) {
-      if (is_interrupted()) break;
+      if (is_interrupted()) {
+        aborted = true;
+        break;
+      }
       await process_message(
         ctx,
         connector,
@@ -244,6 +260,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
   return {
     entries,
     delta_link: delta.delta_link,
+    complete: !aborted,
     stored: stats.stored,
     deduplicated: stats.deduplicated,
     attachments_stored: stats.att_stored,

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -124,7 +124,9 @@ export class MailboxSyncService implements BackupUseCase {
         }
 
         all_entries.push(...outcome.entries);
-        if (outcome.delta_link) {
+        // Persist a folder's delta link only when every page was fully processed;
+        // an interrupted folder keeps its previous link and is re-enumerated next run (issue #23).
+        if (outcome.delta_link && outcome.complete) {
           new_delta_links[folder.folder_id] = outcome.delta_link;
         }
         stored += outcome.stored;
@@ -197,6 +199,7 @@ export class MailboxSyncService implements BackupUseCase {
   ): Promise<{
     entries: ManifestEntry[];
     delta_link?: string;
+    complete: boolean;
     stored: number;
     deduplicated: number;
     attachments_stored: number;
@@ -229,6 +232,7 @@ export class MailboxSyncService implements BackupUseCase {
       return {
         entries: result.entries,
         ...(result.delta_link !== undefined ? { delta_link: result.delta_link } : {}),
+        complete: result.complete,
         stored: result.stored,
         deduplicated: result.deduplicated,
         attachments_stored: result.attachments_stored,
@@ -238,6 +242,7 @@ export class MailboxSyncService implements BackupUseCase {
       const msg = err instanceof Error ? err.message : String(err);
       return {
         entries: [],
+        complete: false,
         stored: 0,
         deduplicated: 0,
         attachments_stored: 0,

--- a/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
+import {
+  MAILBOX_CONNECTOR_TOKEN,
+  MANIFEST_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@wisecom/atlas-types';
+import type {
+  DeltaPageCallback,
+  DeltaSyncResult,
+  MailboxConnector,
+  Manifest,
+  MailFolder,
+  MailMessage,
+  ManifestRepository,
+  ObjectStorage,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+
+// Regression tests for issue #23: a soft interrupt must never persist a delta
+// link that was advanced past unprocessed messages.
+
+function make_message(id: string): MailMessage {
+  const raw = Buffer.from(`body-${id}`);
+  return {
+    message_id: id,
+    folder_id: 'folder-1',
+    subject: `Subject ${id}`,
+    received_at: new Date(),
+    size_bytes: raw.length,
+    raw_body: raw,
+    has_attachments: false,
+  };
+}
+
+const FOLDER: MailFolder = { folder_id: 'folder-1', display_name: 'Inbox', total_item_count: 10 };
+
+const PREVIOUS_MANIFEST: Manifest = {
+  id: 'old-manifest',
+  tenant_id: 't',
+  owner_id: 'user@test.com',
+  snapshot_id: 'old-snap',
+  created_at: new Date(),
+  total_objects: 0,
+  total_size_bytes: 0,
+  delta_links: { 'folder-1': 'https://prev-delta' },
+  entries: [],
+};
+
+/**
+ * Simulates the real Graph adapter's paging loop: on_page per page, the
+ * deltaLink is captured on the final page BEFORE the should_continue check
+ * (mirrors graph-mailbox-connector execute_delta_sync), paging stops when the
+ * callback returns false.
+ */
+function make_streaming_fetch_delta(
+  pages: MailMessage[][],
+  final_delta_link: string,
+  after_page?: (page_num: number) => void,
+) {
+  return vi.fn(
+    async (
+      _tenant: string,
+      _owner: string,
+      _folder: string,
+      _prev?: string,
+      on_page?: DeltaPageCallback,
+    ): Promise<DeltaSyncResult> => {
+      let delta_link = '';
+      let streamed = 0;
+      for (let i = 0; i < pages.length; i++) {
+        const page = pages[i]!;
+        streamed += page.length;
+        if (i === pages.length - 1) delta_link = final_delta_link;
+        const cont = on_page ? await on_page(i + 1, streamed, page) : true;
+        after_page?.(i + 1);
+        if (cont === false) break;
+      }
+      return { messages: [], removed_ids: [], delta_link, delta_reset: false };
+    },
+  );
+}
+
+describe('interrupt delta-link safeguard (issue #23)', () => {
+  let storage: ObjectStorage;
+  let manifests: ManifestRepository;
+  let connector: MailboxConnector;
+  let service: MailboxSyncService;
+
+  beforeEach(() => {
+    storage = {
+      put: vi.fn(),
+      get: vi.fn(),
+      get_with_etag: vi.fn(),
+      get_stream: vi.fn(),
+      delete: vi.fn(),
+      delete_version: vi.fn(),
+      exists: vi.fn().mockResolvedValue(false),
+      list: vi.fn().mockResolvedValue([]),
+      list_versions: vi.fn().mockResolvedValue([]),
+      begin_multipart_upload: vi.fn().mockResolvedValue({
+        upload_part: vi.fn(),
+        complete: vi.fn(),
+        abort: vi.fn(),
+      }),
+      copy: vi.fn(),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+      probe_immutability: vi.fn().mockResolvedValue({
+        bucket: 'b',
+        reachable: true,
+        versioning_enabled: true,
+        object_lock_enabled: true,
+        mode_supported: true,
+      }),
+    };
+    const context: TenantContext = {
+      tenant_id: 't',
+      storage,
+      encrypt: vi.fn((data: Buffer) => data),
+      decrypt: vi.fn((data: Buffer) => data),
+      create_cipher: stub_tenant_create_cipher,
+      create_decipher: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const factory: TenantContextFactory = {
+      create: vi.fn().mockResolvedValue(context),
+      create_storage_only: vi.fn(),
+    };
+    manifests = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn().mockResolvedValue(undefined),
+      find_latest_by_owner: vi.fn().mockResolvedValue(PREVIOUS_MANIFEST),
+      list_all_manifests: vi.fn().mockResolvedValue([]),
+    };
+    connector = {
+      list_mailboxes: vi.fn().mockResolvedValue([]),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
+      list_mail_folders: vi.fn().mockResolvedValue([FOLDER]),
+      fetch_delta: vi.fn(),
+      fetch_message: vi.fn(),
+      fetch_attachments: vi.fn().mockResolvedValue([]),
+    };
+
+    const container = new Container();
+    container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(connector);
+    container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(manifests);
+    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
+    container.bind(MailboxSyncService).toSelf();
+    service = container.get(MailboxSyncService);
+  });
+
+  function saved_delta_links(): Record<string, string> {
+    const calls = vi.mocked(manifests.save).mock.calls;
+    expect(calls.length).toBe(1);
+    return calls[0]![1].delta_links;
+  }
+
+  it('keeps the previous delta link when interrupted after page 1 of 3', async () => {
+    let interrupted = false;
+    const pages = [
+      [make_message('m1'), make_message('m2')],
+      [make_message('m3')],
+      [make_message('m4')],
+    ];
+    connector.fetch_delta = make_streaming_fetch_delta(pages, 'https://new-delta', (page) => {
+      if (page === 1) interrupted = true;
+    });
+
+    await service.sync_mailbox('t', 'user@test.com', {
+      should_interrupt: () => interrupted,
+    });
+
+    // page 1 was fully processed (2 unique bodies stored), pages 2-3 never were
+    expect(vi.mocked(storage.put).mock.calls.length).toBe(2);
+    expect(saved_delta_links()).toEqual({ 'folder-1': 'https://prev-delta' });
+  });
+
+  it('does not persist a delta link captured on an interrupted final page', async () => {
+    // Interrupt flips after the first stored message: the single (final) page
+    // carries the deltaLink, which the adapter captures before the callback
+    // result is evaluated - completeness gating is the only protection here.
+    let interrupted = false;
+    vi.mocked(storage.put).mockImplementation(async () => {
+      interrupted = true;
+    });
+    const pages = [[make_message('m1'), make_message('m2'), make_message('m3')]];
+    connector.fetch_delta = make_streaming_fetch_delta(pages, 'https://new-delta');
+
+    await service.sync_mailbox('t', 'user@test.com', {
+      should_interrupt: () => interrupted,
+    });
+
+    expect(saved_delta_links()).toEqual({ 'folder-1': 'https://prev-delta' });
+  });
+
+  it('persists the new delta link when the folder completes without interrupt', async () => {
+    const pages = [[make_message('m1')], [make_message('m2')]];
+    connector.fetch_delta = make_streaming_fetch_delta(pages, 'https://new-delta');
+
+    await service.sync_mailbox('t', 'user@test.com');
+
+    expect(saved_delta_links()).toEqual({ 'folder-1': 'https://new-delta' });
+  });
+});


### PR DESCRIPTION
Fixes #23.

A soft interrupt kept paging while skipping message processing, then persisted the folder's final delta link — silently and permanently excluding every skipped message from all future incremental backups.

- `folder-sync-executor`: `aborted` flag on every skip path; `on_page` returns `false` on soft interrupt; `FolderSyncResult.complete` added
- `mailbox-sync.service`: delta link persisted only when `complete` — interrupted folders keep their previous link and are re-enumerated (deduped) next run
- Side fix: empty-folder full-resync fallback gated on `!aborted` so a hard stop can't trigger spurious full re-enumeration

Key detail: the completeness gate (not just `return false`) is required because the Graph adapter captures `@odata.deltaLink` **before** evaluating the page-callback result — an interrupt on the final page still yields an advanced link.

**Tests**: 3 regression tests in `interrupt-delta-safeguard.test.ts`, verified red on unfixed code. Outlook suite 178/178, lint clean. See issue comment for full verification recap.