### PR TITLE
fix(outlook): download large attachments via $value instead of silently skipping

### DIFF
--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'inversify';
 import type { Client } from '@microsoft/microsoft-graph-client';
+import { ResponseType } from '@microsoft/microsoft-graph-client';
 import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
 import type {
   MailboxConnector,
@@ -169,8 +170,9 @@ export class GraphMailboxConnector implements MailboxConnector {
 
   /**
    * Fetches file attachments for a message. Filters to fileAttachment type only,
-   * decodes contentBytes from base64. Logs a warning and skips storage for
-   * attachments where contentBytes is missing (typically >4MB).
+   * decodes contentBytes from base64. Attachments above the Graph inline limit
+   * (~3 MB) arrive without contentBytes and are downloaded individually via the
+   * /$value endpoint, which streams raw bytes with no size ceiling.
    */
   async fetch_attachments(
     _tenant_id: string,
@@ -182,12 +184,42 @@ export class GraphMailboxConnector implements MailboxConnector {
       const records = await with_graph_retry(() =>
         this.collect_all_pages<GraphAttachmentRecord>(url),
       );
-      return map_file_attachments(records);
+      const attachments = map_file_attachments(records);
+
+      for (let i = 0; i < attachments.length; i++) {
+        const att = attachments[i]!;
+        if (att.content.length > 0 || att.size_bytes === 0 || !att.attachment_id) continue;
+        const content = await this.download_attachment_content(
+          owner_id,
+          message_id,
+          att.attachment_id,
+        );
+        attachments[i] = { ...att, content };
+      }
+      return attachments;
     } catch (err) {
       rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }
+  }
+
+  /**
+   * Downloads raw attachment bytes via /attachments/{id}/$value. Raw transfer
+   * avoids the +33% base64 overhead of contentBytes. Each attachment gets its
+   * own retry window so a large binary cannot starve the page-listing budget.
+   */
+  private async download_attachment_content(
+    owner_id: string,
+    message_id: string,
+    attachment_id: string,
+  ): Promise<Buffer> {
+    const url = `/users/${owner_id}/messages/${message_id}/attachments/${attachment_id}/$value`;
+    const data = await with_graph_retry(
+      () =>
+        this._client.api(url).responseType(ResponseType.ARRAYBUFFER).get() as Promise<ArrayBuffer>,
+    );
+    return Buffer.from(data);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/outlook/src/adapters/graph-mailbox-response-mappers.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-response-mappers.ts
@@ -106,7 +106,11 @@ export function map_users_to_tenant_mailboxes(users: GraphUserRecord[]): TenantM
     });
 }
 
-/** Filters to fileAttachment, decodes base64 content, warns on missing bytes. */
+/**
+ * Filters to fileAttachment and decodes base64 content. Records without
+ * contentBytes (above the Graph inline limit) are returned with an empty
+ * buffer; the connector downloads their binary separately via /$value.
+ */
 export function map_file_attachments(records: GraphAttachmentRecord[]): MessageAttachment[] {
   const results: MessageAttachment[] = [];
 
@@ -114,9 +118,9 @@ export function map_file_attachments(records: GraphAttachmentRecord[]): MessageA
     if (r['@odata.type'] !== '#microsoft.graph.fileAttachment') continue;
 
     if (!r.contentBytes) {
-      logger.warn(
-        `Attachment "${r.name ?? '?'}" (${r.size ?? 0} bytes) has no contentBytes -- ` +
-          `likely exceeds Graph API inline limit (>4MB). Metadata recorded, binary skipped.`,
+      logger.debug(
+        `Attachment "${r.name ?? '?'}" (${r.size ?? 0} bytes) has no inline contentBytes -- ` +
+          `will download via /$value`,
       );
       results.push({
         attachment_id: r.id ?? '',

--- a/packages/outlook/tests/unit/graph-attachment-fetch.test.ts
+++ b/packages/outlook/tests/unit/graph-attachment-fetch.test.ts
@@ -1,27 +1,36 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
 import { Container } from 'inversify';
 import { GraphMailboxConnector } from '@/adapters/graph-mailbox-connector.adapter';
 import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
 
 interface MockChain {
-  select: ReturnType<typeof vi.fn>;
-  top: ReturnType<typeof vi.fn>;
-  header: ReturnType<typeof vi.fn>;
-  get: ReturnType<typeof vi.fn>;
+  select: Mock;
+  top: Mock;
+  header: Mock;
+  responseType: Mock;
+  get: Mock;
 }
 
 interface MockClient {
-  api: ReturnType<typeof vi.fn>;
+  api: Mock;
   _chain: MockChain;
 }
 
 function create_mock_client(): MockClient {
   const get_fn = vi.fn();
-  const chain: MockChain = { select: vi.fn(), top: vi.fn(), header: vi.fn(), get: get_fn };
+  const chain: MockChain = {
+    select: vi.fn(),
+    top: vi.fn(),
+    header: vi.fn(),
+    responseType: vi.fn(),
+    get: get_fn,
+  };
   chain.select.mockReturnValue(chain);
   chain.top.mockReturnValue(chain);
   chain.header.mockReturnValue(chain);
+  chain.responseType.mockReturnValue(chain);
   const api_fn = vi.fn().mockReturnValue(chain);
   return { api: api_fn, _chain: chain };
 }
@@ -71,15 +80,44 @@ describe('GraphMailboxConnector – fetch_attachments', () => {
     expect(result[0]!.is_inline).toBe(false);
   });
 
-  it('returns empty buffer for attachments without contentBytes (>4MB)', async () => {
+  it('downloads content via /$value for attachments without contentBytes', async () => {
+    const raw_bytes = Buffer.from('binary-payload-of-a-large-zip');
+    mock_client._chain.get
+      .mockResolvedValueOnce({
+        value: [
+          {
+            '@odata.type': '#microsoft.graph.fileAttachment',
+            id: 'att-big',
+            name: 'huge.zip',
+            contentType: 'application/zip',
+            size: 50_000_000,
+            isInline: false,
+          },
+        ],
+      })
+      .mockResolvedValueOnce(
+        raw_bytes.buffer.slice(raw_bytes.byteOffset, raw_bytes.byteOffset + raw_bytes.byteLength),
+      );
+
+    const result = await connector.fetch_attachments('tenant-1', 'user-1', 'msg-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe('huge.zip');
+    expect(result[0]!.content).toEqual(raw_bytes);
+    expect(mock_client.api).toHaveBeenCalledWith(
+      '/users/user-1/messages/msg-1/attachments/att-big/$value',
+    );
+  });
+
+  it('does not call /$value for zero-size attachments without contentBytes', async () => {
     mock_client._chain.get.mockResolvedValueOnce({
       value: [
         {
           '@odata.type': '#microsoft.graph.fileAttachment',
-          id: 'att-big',
-          name: 'huge.zip',
-          contentType: 'application/zip',
-          size: 50_000_000,
+          id: 'att-empty',
+          name: 'empty.txt',
+          contentType: 'text/plain',
+          size: 0,
           isInline: false,
         },
       ],
@@ -88,8 +126,8 @@ describe('GraphMailboxConnector – fetch_attachments', () => {
     const result = await connector.fetch_attachments('tenant-1', 'user-1', 'msg-1');
 
     expect(result).toHaveLength(1);
-    expect(result[0]!.name).toBe('huge.zip');
     expect(result[0]!.content.length).toBe(0);
+    expect(mock_client.api).toHaveBeenCalledTimes(1);
   });
 
   it('handles inline attachments with isInline flag', async () => {


### PR DESCRIPTION
Fixes #24.

Attachments above the Graph inline limit (~3 MB) arrive from the list endpoint without `contentBytes` and were stored as metadata-only entries — silent data loss surfacing only at restore.

- `fetch_attachments` downloads missing binaries via `GET .../attachments/{id}/$value` (`ResponseType.ARRAYBUFFER`): raw bytes, no size ceiling, no base64 inflation
- Per-attachment `with_graph_retry` windows — addresses the #33 interaction flagged in the issue comments
- Persistent download failure now fails the sync loudly instead of silently storing nothing
- Restore half (two-tier upload) already existed in `graph-restore-connector` — no change needed

**Tests**: new `$value` cases in `graph-attachment-fetch.test.ts` verified red on unfixed code; outlook suite 176/176; lint clean. Full verification recap on the issue.