### PR TITLE
fix(s3): make DEK bootstrap race-safe with create-only conditional write

### DIFF
--- a/docs/self-hosting/storage.md
+++ b/docs/self-hosting/storage.md
@@ -141,3 +141,29 @@ MinIO supports TLS natively by placing certificate files in the container. See t
 ```env
 ATLAS_S3_ENDPOINT="https://minio.internal:9000"
 ```
+
+### Protecting the Tenant Encryption Key
+
+Each tenant bucket stores its wrapped data-encryption key at `_meta/dek.enc`. Atlas writes this object exactly once, with a create-only conditional write (`If-None-Match: *`, supported by AWS S3 and MinIO): if two processes bootstrap the same tenant concurrently, the second write fails with `412 Precondition Failed` and that process adopts the already-stored key. Overwriting a live DEK would make every object encrypted with it permanently undecryptable.
+
+As defense in depth, a bucket policy can *mandate* the create-only header on the key object, so even a buggy or outdated client cannot overwrite it (AWS S3; uses the [`s3:if-none-match` condition key](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes-enforce.html)):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyDekOverwrite",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::atlas-*/_meta/dek.enc",
+      "Condition": { "StringNotEquals": { "s3:if-none-match": "*" } }
+    }
+  ]
+}
+```
+
+::: warning S3-compatible stores
+Some S3-compatible backends (older MinIO releases, some Ceph RGW versions, various emulators) silently ignore unknown conditional headers instead of rejecting the write. On such a backend the create-only guarantee is illusory -- verify support by writing the same key twice with `If-None-Match: *` and confirming the second write fails with 412. Atlas additionally reads the stored key back after bootstrap and always proceeds with what storage actually holds, which converges concurrent bootstraps even where the header is ignored.
+:::

--- a/packages/s3/src/adapters/object-lock.errors.ts
+++ b/packages/s3/src/adapters/object-lock.errors.ts
@@ -25,10 +25,12 @@ export class ObjectLockModeRejectedError extends Error {
   }
 }
 
-/** Thrown when a conditional put fails because the ETag no longer matches. */
+/** Thrown when a conditional put fails (ETag mismatch or create-only key already exists). */
 export class PreconditionFailedError extends Error {
   constructor(key: string) {
-    super(`Conditional write failed for key ${key} — ETag mismatch (412 Precondition Failed)`);
+    super(
+      `Conditional write failed for key ${key} — precondition not met (412 Precondition Failed)`,
+    );
     this.name = 'PreconditionFailedError';
   }
 }

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -51,6 +51,7 @@ export class S3ObjectStorage implements ObjectStorage {
     metadata?: Record<string, string>,
     object_lock_policy?: StorageObjectLockPolicy,
     if_match?: string,
+    if_none_match?: boolean,
   ): Promise<void> {
     await this.validate_immutability_policy(object_lock_policy);
     const content_md5 = createHash('md5').update(data).digest('base64');
@@ -68,6 +69,7 @@ export class S3ObjectStorage implements ObjectStorage {
             ? new Date(object_lock_policy.retain_until)
             : undefined,
           ...(if_match ? { IfMatch: if_match } : {}),
+          ...(if_none_match ? { IfNoneMatch: '*' } : {}),
         }),
       );
     } catch (err) {

--- a/packages/s3/src/adapters/tenant-context.factory.ts
+++ b/packages/s3/src/adapters/tenant-context.factory.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from 'inversify';
 import type { S3Client } from '@aws-sdk/client-s3';
 import { S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
+import { PreconditionFailedError } from '@/adapters/object-lock.errors';
 import { ensure_bucket_exists } from '@/adapters/s3-bucket-manager';
 import { tenant_bucket_name } from '@/adapters/tenant-bucket-name';
 import { EnvelopeKeyService, ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
@@ -49,7 +50,7 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
     };
   }
 
-  /** Loads an existing DEK or generates and wraps a new one. */
+  /** Loads an existing DEK or creates one with a race-safe conditional write. */
   private async load_or_create_dek(
     storage: S3ObjectStorage,
     key_service: EnvelopeKeyService,
@@ -61,10 +62,43 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
       const wrapped = await storage.get(DEK_META_KEY);
       return key_service.unwrap_dek(wrapped, tenant_id);
     }
+    return this.create_dek_exclusively(storage, key_service, tenant_id);
+  }
 
+  /**
+   * Persists a freshly generated DEK with a create-only conditional write
+   * (If-None-Match: *). If a concurrent bootstrap wins the race, the write
+   * fails with 412 and the winner's key is adopted. The key is then read
+   * back and unwrapped so the DEK in use is always exactly what storage
+   * holds - verified before any tenant data is encrypted with it. Unwrap
+   * failure here is fatal by design: a DEK is never regenerated over an
+   * existing one.
+   */
+  private async create_dek_exclusively(
+    storage: S3ObjectStorage,
+    key_service: EnvelopeKeyService,
+    tenant_id: string,
+  ): Promise<Buffer> {
     logger.info(`Generating new encryption key for tenant ${tenant_id}`);
     const dek = key_service.generate_dek();
-    await storage.put(DEK_META_KEY, key_service.wrap_dek(dek, tenant_id));
-    return dek;
+
+    try {
+      const wrapped = key_service.wrap_dek(dek, tenant_id);
+      await storage.put(DEK_META_KEY, wrapped, undefined, undefined, undefined, true);
+    } catch (err) {
+      if (!(err instanceof PreconditionFailedError)) throw err;
+      logger.warn(
+        `Tenant ${tenant_id}: concurrent key bootstrap detected -- adopting the already stored key`,
+      );
+    }
+
+    const stored = await storage.get(DEK_META_KEY);
+    const stored_dek = key_service.unwrap_dek(stored, tenant_id);
+    if (!stored_dek.equals(dek)) {
+      logger.warn(
+        `Tenant ${tenant_id}: stored key differs from the locally generated one -- using stored key`,
+      );
+    }
+    return stored_dek;
   }
 }

--- a/packages/s3/tests/unit/s3-object-storage.test.ts
+++ b/packages/s3/tests/unit/s3-object-storage.test.ts
@@ -4,6 +4,7 @@ import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
 import {
   ObjectLockUnsupportedError,
   ObjectLockVersioningDisabledError,
+  PreconditionFailedError,
 } from '@/adapters/object-lock.errors';
 
 function make_mock_s3(): { send: ReturnType<typeof vi.fn> } {
@@ -47,6 +48,28 @@ describe('S3ObjectStorage', () => {
 
       const cmd = mock_s3.send.mock.calls[0][0];
       expect(cmd.input.ContentMD5).toBe(expected_md5);
+    });
+
+    it('maps if_none_match to a create-only IfNoneMatch header', async () => {
+      mock_s3.send.mockResolvedValueOnce({});
+
+      await storage.put('k', Buffer.from('v'), undefined, undefined, undefined, true);
+
+      const cmd = mock_s3.send.mock.calls[0][0];
+      expect(cmd.input.IfNoneMatch).toBe('*');
+      expect(cmd.input.IfMatch).toBeUndefined();
+    });
+
+    it('throws PreconditionFailedError when a create-only write hits an existing key', async () => {
+      const err = Object.assign(new Error('PreconditionFailed'), {
+        name: 'PreconditionFailed',
+        $metadata: { httpStatusCode: 412 },
+      });
+      mock_s3.send.mockRejectedValueOnce(err);
+
+      await expect(
+        storage.put('k', Buffer.from('v'), undefined, undefined, undefined, true),
+      ).rejects.toBeInstanceOf(PreconditionFailedError);
     });
 
     it('applies object lock options for immutable upload', async () => {

--- a/packages/s3/tests/unit/tenant-context-dek-bootstrap.test.ts
+++ b/packages/s3/tests/unit/tenant-context-dek-bootstrap.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
+import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+
+// Regression tests for issue #25: two processes bootstrapping the same fresh
+// tenant concurrently must converge on one DEK - the loser of the create-only
+// write adopts the winner's key instead of overwriting it.
+
+interface CommandLike {
+  input: { Key?: string; Bucket?: string; Body?: Buffer; IfNoneMatch?: string };
+}
+
+/**
+ * Stateful in-memory S3 fake: HeadBucket always succeeds, objects live in a
+ * shared map, and PutObject honours IfNoneMatch: '*' with a 412 like AWS S3.
+ * The first `force_missing_heads` HeadObject calls report 404 regardless of
+ * state, so two racing factories both observe "no DEK yet".
+ */
+function make_racing_s3(force_missing_heads: number) {
+  const objects = new Map<string, Buffer>();
+  let head_count = 0;
+
+  const not_found = () =>
+    Object.assign(new Error('NotFound'), { name: 'NotFound', $metadata: { httpStatusCode: 404 } });
+
+  const send = vi.fn(async (cmd: CommandLike) => {
+    const name = cmd.constructor.name;
+    const key = cmd.input.Key ?? '';
+
+    if (name === 'HeadBucketCommand') return {};
+    if (name === 'HeadObjectCommand') {
+      if (++head_count <= force_missing_heads || !objects.has(key)) throw not_found();
+      return {};
+    }
+    if (name === 'PutObjectCommand') {
+      if (cmd.input.IfNoneMatch === '*' && objects.has(key)) {
+        throw Object.assign(new Error('PreconditionFailed'), {
+          name: 'PreconditionFailed',
+          $metadata: { httpStatusCode: 412 },
+        });
+      }
+      objects.set(key, Buffer.from(cmd.input.Body ?? Buffer.alloc(0)));
+      return {};
+    }
+    if (name === 'GetObjectCommand') {
+      const data = objects.get(key);
+      if (!data) throw not_found();
+      return { Body: { transformToByteArray: async () => new Uint8Array(data) } };
+    }
+    throw new Error(`Unexpected command in fake S3: ${name}`);
+  });
+
+  return { send, objects };
+}
+
+const CONFIG = { encryption_passphrase: 'unit-test-passphrase-long' } as AtlasConfig;
+
+function make_factory(s3: { send: ReturnType<typeof vi.fn> }): DefaultTenantContextFactory {
+  return new DefaultTenantContextFactory(s3 as never, CONFIG);
+}
+
+describe('DEK bootstrap race (issue #25)', () => {
+  beforeEach(() => {
+    reset_bucket_cache();
+  });
+
+  it('two concurrent bootstraps of a fresh tenant converge on one DEK', async () => {
+    const s3 = make_racing_s3(2);
+    const [ctx_a, ctx_b] = await Promise.all([
+      make_factory(s3).create('tenant-race'),
+      make_factory(s3).create('tenant-race'),
+    ]);
+
+    // exactly one wrapped DEK object exists
+    expect(s3.objects.size).toBe(1);
+
+    // data encrypted by either context decrypts with the other
+    const secret = Buffer.from('cross-process payload');
+    expect(ctx_b.decrypt(ctx_a.encrypt(secret))).toEqual(secret);
+    expect(ctx_a.decrypt(ctx_b.encrypt(secret))).toEqual(secret);
+  });
+
+  it('a later bootstrap loads the existing DEK instead of writing', async () => {
+    const s3 = make_racing_s3(0);
+    const ctx_first = await make_factory(s3).create('tenant-1');
+    const put_calls_after_first = s3.send.mock.calls.filter(
+      ([cmd]) => (cmd as CommandLike).constructor.name === 'PutObjectCommand',
+    ).length;
+
+    const ctx_second = await make_factory(s3).create('tenant-1');
+
+    const put_calls_total = s3.send.mock.calls.filter(
+      ([cmd]) => (cmd as CommandLike).constructor.name === 'PutObjectCommand',
+    ).length;
+    expect(put_calls_total).toBe(put_calls_after_first);
+
+    const secret = Buffer.from('same key across runs');
+    expect(ctx_second.decrypt(ctx_first.encrypt(secret))).toEqual(secret);
+  });
+
+  it('every DEK write is create-only', async () => {
+    const s3 = make_racing_s3(0);
+    await make_factory(s3).create('tenant-2');
+
+    const dek_puts = s3.send.mock.calls.filter(([cmd]) => {
+      const c = cmd as CommandLike;
+      return c.constructor.name === 'PutObjectCommand' && c.input.Key === '_meta/dek.enc';
+    });
+    expect(dek_puts.length).toBe(1);
+    expect((dek_puts[0]![0] as CommandLike).input.IfNoneMatch).toBe('*');
+  });
+});

--- a/packages/types/src/ports/storage/object-storage.port.ts
+++ b/packages/types/src/ports/storage/object-storage.port.ts
@@ -41,13 +41,19 @@ export interface ObjectStorageEtagResult {
 }
 
 export interface ObjectStorage {
-  /** Writes an object to storage under the given key. */
+  /**
+   * Writes an object to storage under the given key.
+   * `if_match` performs a compare-and-swap on the ETag; `if_none_match` makes
+   * the write create-only (fails if the key exists). Both reject with a
+   * precondition error (HTTP 412) when the condition does not hold.
+   */
   put(
     key: string,
     data: Buffer,
     metadata?: Record<string, string>,
     object_lock_policy?: StorageObjectLockPolicy,
     if_match?: string,
+    if_none_match?: boolean,
   ): Promise<void>;
 
   /** Reads the full content of an object from storage. */


### PR DESCRIPTION
Fixes #25.

Concurrent first-run bootstraps of the same tenant could overwrite a live DEK (non-atomic `exists`→`put`), making all data encrypted with the losing key permanently undecryptable.

- `ObjectStorage.put` gains `if_none_match` → `IfNoneMatch: '*'` (create-only), symmetric with existing `if_match`/412 plumbing
- Bootstrap: create-only put → on 412 adopt the winner; stored key is always read back, unwrapped and used (round-trip verify before any data is encrypted; unwrap failure fatal — never regenerate)
- Docs: `s3:if-none-match` bucket-policy hardening + warning for backends that silently ignore conditional headers

Deliberately skipped the `storage-check` write-twice probe — it would leave undeletable objects in Object-Lock buckets; rationale on the issue.

**Tests**: acceptance concurrency test (two factories → one DEK, cross-context decrypt) red on unfixed code; workspace suite 645 green.