### PR TITLE
fix(replication): refuse DEK overwrite unless the key is the bucket's only object

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -626,3 +626,7 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 ::: danger Rehydration Is Not Sync
 Rehydration copies explicitly selected data from a designated replica to primary. It does not merge, diff, or resolve conflicts. After rehydration, primary resumes as the source of truth. Delta links in recovered manifests may be stale -- Atlas falls back to full sync on the next backup automatically.
 :::
+
+::: warning Encryption Key Safety
+Rehydration needs the source replica's encryption key (`_meta/dek.enc`) on the primary. Atlas copies it automatically when the primary has none, and replaces it only when the key is provably the sole object in the primary bucket (a freshly auto-initialized bucket). If the primary already contains **any** other object -- Outlook, OneDrive, or SharePoint data, or replication records -- and its key differs from the source's, rehydration aborts with `DekOverwriteRefusedError` instead of making that data permanently undecryptable. If the primary's content is disposable, run `atlas delete --purge` first and rehydrate into the empty bucket.
+:::

--- a/packages/core/src/services/replication/rehydration-dek-helper.ts
+++ b/packages/core/src/services/replication/rehydration-dek-helper.ts
@@ -1,14 +1,34 @@
 import type { StorageTarget } from '@wisecom/atlas-types';
+import { logger } from '@/utils/logger';
 
 const DEK_META_KEY = '_meta/dek.enc';
 
+/** Thrown when replacing the primary's DEK could destroy existing ciphertext. */
+export class DekOverwriteRefusedError extends Error {
+  constructor(tenant_id: string) {
+    super(
+      `Refusing to replace the encryption key of tenant ${tenant_id}: the primary bucket ` +
+        `holds a key AND other objects, so the key may protect existing backups. ` +
+        `Overwriting it would make that data permanently undecryptable. If the primary's ` +
+        `content is disposable, purge the tenant (atlas delete --purge) and rerun ` +
+        `rehydration into the empty bucket.`,
+    );
+    this.name = 'DekOverwriteRefusedError';
+  }
+}
+
 /**
- * For rehydration to an empty primary, the TenantContextFactory auto-generates
- * a new random DEK on first access. This would conflict with the source's DEK.
+ * Rehydration copies ciphertext encrypted with the source DEK, so the primary
+ * must hold that exact DEK. Copies it when the primary has none; replaces an
+ * existing one only when the primary bucket provably contains nothing but the
+ * auto-generated key itself (the only object a fresh bucket holds). Anything
+ * else aborts with DekOverwriteRefusedError.
  *
- * This helper checks if primary has a DEK. If not, it copies the source's DEK.
- * If primary has a DEK but no manifests (auto-generated on an empty bucket),
- * it overwrites with the source's DEK so rehydration can proceed.
+ * The emptiness check lists the whole bucket (2 keys suffice) instead of
+ * known data prefixes: prefix knowledge went stale once before when OneDrive
+ * and SharePoint added their own layouts, silently misclassifying data-bearing
+ * primaries as empty (issue #26). A whole-bucket check is immune to new
+ * domains by construction.
  */
 export async function ensure_source_dek_on_primary(
   primary: StorageTarget,
@@ -19,18 +39,24 @@ export async function ensure_source_dek_on_primary(
   const source_has_dek = await source_ctx.storage.exists(DEK_META_KEY);
   if (!source_has_dek) return;
 
+  const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
   const primary_ctx = await primary.create_context(tenant_id);
   const primary_has_dek = await primary_ctx.storage.exists(DEK_META_KEY);
 
   if (!primary_has_dek) {
-    const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
     await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
     return;
   }
 
-  const has_manifests = (await primary_ctx.storage.list('manifests/')).length > 0;
-  if (has_manifests) return;
+  const primary_dek_blob = await primary_ctx.storage.get(DEK_META_KEY);
+  if (primary_dek_blob.equals(source_dek_blob)) return;
 
-  const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
+  const keys = await primary_ctx.storage.list('', 2);
+  const only_the_dek = keys.length === 1 && keys[0] === DEK_META_KEY;
+  if (!only_the_dek) throw new DekOverwriteRefusedError(tenant_id);
+
+  logger.info(
+    `Tenant ${tenant_id}: replacing the auto-generated key on the empty primary with the source key`,
+  );
   await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
 }

--- a/packages/core/tests/unit/services/replication/rehydration-dek-helper.test.ts
+++ b/packages/core/tests/unit/services/replication/rehydration-dek-helper.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ensure_source_dek_on_primary,
+  DekOverwriteRefusedError,
+} from '@/services/replication/rehydration-dek-helper';
+import type { ObjectStorage, StorageTarget, TenantContext } from '@wisecom/atlas-types';
+
+// Regression tests for issue #26: a primary holding only OneDrive/SharePoint
+// backups must never be misclassified as empty and have its DEK overwritten.
+
+const DEK_KEY = '_meta/dek.enc';
+const SOURCE_DEK = Buffer.from('wrapped-source-dek');
+const PRIMARY_DEK = Buffer.from('wrapped-primary-dek');
+
+interface FakeBucket {
+  storage: ObjectStorage;
+  target: StorageTarget;
+}
+
+/** Storage target stub whose bucket holds the given key->blob map. */
+function make_target(objects: Record<string, Buffer>): FakeBucket {
+  const keys = () => Object.keys(objects).sort();
+  const storage = {
+    exists: vi.fn(async (key: string) => key in objects),
+    get: vi.fn(async (key: string) => {
+      const blob = objects[key];
+      if (!blob) throw new Error(`missing ${key}`);
+      return blob;
+    }),
+    put: vi.fn(async (key: string, data: Buffer) => {
+      objects[key] = data;
+    }),
+    list: vi.fn(async (prefix: string, limit?: number) => {
+      const matched = keys().filter((k) => k.startsWith(prefix));
+      return limit === undefined ? matched : matched.slice(0, limit);
+    }),
+  } as unknown as ObjectStorage;
+
+  const context = { tenant_id: 't', storage } as unknown as TenantContext;
+  const target = {
+    target_id: 'target',
+    endpoint: 'http://s3.local',
+    create_context: vi.fn(async () => context),
+  } as unknown as StorageTarget;
+
+  return { storage, target };
+}
+
+describe('ensure_source_dek_on_primary (issue #26)', () => {
+  let source: FakeBucket;
+
+  beforeEach(() => {
+    source = make_target({ [DEK_KEY]: SOURCE_DEK, 'manifests/m1.json': Buffer.from('m') });
+  });
+
+  it('does nothing when the source has no DEK', async () => {
+    const empty_source = make_target({});
+    const primary = make_target({ [DEK_KEY]: PRIMARY_DEK });
+
+    await ensure_source_dek_on_primary(primary.target, empty_source.target, 't');
+
+    expect(primary.storage.put).not.toHaveBeenCalled();
+  });
+
+  it('copies the source DEK when the primary has none', async () => {
+    const primary = make_target({});
+
+    await ensure_source_dek_on_primary(primary.target, source.target, 't');
+
+    expect(primary.storage.put).toHaveBeenCalledWith(DEK_KEY, SOURCE_DEK);
+  });
+
+  it('leaves an identical DEK untouched', async () => {
+    const primary = make_target({ [DEK_KEY]: Buffer.from(SOURCE_DEK) });
+
+    await ensure_source_dek_on_primary(primary.target, source.target, 't');
+
+    expect(primary.storage.put).not.toHaveBeenCalled();
+  });
+
+  it('replaces the DEK when it is the only object in the bucket', async () => {
+    const primary = make_target({ [DEK_KEY]: PRIMARY_DEK });
+
+    await ensure_source_dek_on_primary(primary.target, source.target, 't');
+
+    expect(primary.storage.put).toHaveBeenCalledWith(DEK_KEY, SOURCE_DEK);
+    expect(primary.storage.list).toHaveBeenCalledWith('', 2);
+  });
+
+  it('refuses to overwrite when the primary holds OneDrive-only backups', async () => {
+    const primary = make_target({
+      [DEK_KEY]: PRIMARY_DEK,
+      'onedrive/manifests/owner-1/snap-1.json': Buffer.from('drive manifest'),
+    });
+
+    await expect(
+      ensure_source_dek_on_primary(primary.target, source.target, 't'),
+    ).rejects.toBeInstanceOf(DekOverwriteRefusedError);
+
+    expect(primary.storage.put).not.toHaveBeenCalled();
+  });
+
+  it('refuses to overwrite when the primary holds only replication sidecars', async () => {
+    const primary = make_target({
+      [DEK_KEY]: PRIMARY_DEK,
+      '_meta/replication/mbx-1/snap-1/offsite.json': Buffer.from('sidecar'),
+    });
+
+    await expect(
+      ensure_source_dek_on_primary(primary.target, source.target, 't'),
+    ).rejects.toBeInstanceOf(DekOverwriteRefusedError);
+
+    expect(primary.storage.put).not.toHaveBeenCalled();
+  });
+});

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -150,8 +150,8 @@ export class S3ObjectStorage implements ObjectStorage {
     }
   }
 
-  /** Lists all keys sharing the given prefix. */
-  async list(prefix: string): Promise<string[]> {
+  /** Lists keys sharing the given prefix; `limit` stops enumeration early. */
+  async list(prefix: string, limit?: number): Promise<string[]> {
     const keys: string[] = [];
     let continuation_token: string | undefined;
 
@@ -161,12 +161,14 @@ export class S3ObjectStorage implements ObjectStorage {
           Bucket: this._bucket,
           Prefix: prefix,
           ContinuationToken: continuation_token,
+          ...(limit !== undefined ? { MaxKeys: Math.min(limit, 1000) } : {}),
         }),
       );
 
       for (const obj of response.Contents ?? []) {
         if (obj.Key) keys.push(obj.Key);
       }
+      if (limit !== undefined && keys.length >= limit) return keys.slice(0, limit);
       continuation_token = response.NextContinuationToken;
     } while (continuation_token);
 

--- a/packages/types/src/ports/storage/object-storage.port.ts
+++ b/packages/types/src/ports/storage/object-storage.port.ts
@@ -65,8 +65,12 @@ export interface ObjectStorage {
   /** Returns true if the key exists in storage. */
   exists(key: string): Promise<boolean>;
 
-  /** Lists all keys that share the given prefix. */
-  list(prefix: string): Promise<string[]>;
+  /**
+   * Lists keys that share the given prefix. `limit` caps the number of keys
+   * returned and stops enumeration early - use it for cheap existence checks
+   * on potentially large buckets.
+   */
+  list(prefix: string, limit?: number): Promise<string[]>;
 
   /** Lists object versions and delete markers for a prefix. */
   list_versions(prefix: string): Promise<StorageObjectVersion[]>;


### PR DESCRIPTION
Fixes #26.

Rehydration classified a primary as "empty" by checking the Outlook `manifests/` prefix only — a primary holding OneDrive/SharePoint backups had its DEK silently overwritten, destroying all existing ciphertext.

Root cause was prefix-knowledge going stale, so the fix removes prefix knowledge entirely:

- DEK replacement allowed **only when the key is provably the bucket's sole object** (`list('', 2)`, one `ListObjectsV2` call); anything else throws `DekOverwriteRefusedError` before any write — immune to future domains by construction
- Byte-identical DEKs no-op (common replica case)
- `ObjectStorage.list` gains optional early-terminating `limit` (→ `MaxKeys`)
- Docs: rehydrate section documents the refusal + `delete --purge` escape hatch

No `--force`: purge + rehydrate-into-empty is the explicit path for a disposable primary (rationale on the issue).

**Tests**: OneDrive-only primary refusal red on unfixed code (4/6 fail there); core 213 + s3 39 green; lint + docs build clean.