### PR TITLE
fix(backup): apply Object Lock to OneDrive/SharePoint and tenant-wide Outlook runs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -326,9 +326,15 @@ atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
 | --- | --- |
 | `-o, --owner <id>` | User email or Entra object ID (required) |
 | `--full` | Force full crawl ignoring saved delta links |
+| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
+| `--lock-mode <mode>` | Object Lock mode (`governance` or `compliance`, default `governance`) |
 | `-t, --tenant <id>` | Override tenant ID from config |
 
 While the backup runs, a live dashboard shows one row per drive: delta fetch (`fetching changes...`), then per-item progress with rate and ETA, finishing as `[ok]` with stored/dedup/version counts or `[==] up to date` when an incremental delta has no changes. Non-interactive runs (cron/CI) print one plain log line per finished drive instead. Service messages (version syncs, warnings) print above the live region.
+
+::: details Object Lock semantics for OneDrive/SharePoint
+Unlike Outlook (which stamps a per-object `retain_until` on each write), OneDrive and SharePoint apply immutability as **bucket default retention** (`PutObjectLockConfiguration`): every new object version — files, file versions, manifests, delta cursors — inherits the lock automatically, so no write path can bypass it. Two consequences: the setting **persists on the bucket** and covers all subsequent writes from any command, and the bucket must be lock-capable (created with Object Lock; see `atlas storage-check` and the migration runbook in the self-hosting docs) or the backup fails fast with `ObjectLockUnsupportedError`. Frequently-overwritten small objects (cursors, indexes) accumulate locked noncurrent versions until retention expires; the bucket housekeeping lifecycle rules clean them up afterwards.
+:::
 
 **`atlas onedrive restore`**
 
@@ -430,6 +436,8 @@ atlas sharepoint verify --site https://contoso.sharepoint.com/sites/Engineering 
 | --- | --- |
 | `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
 | `--full` | Force full crawl ignoring saved delta links |
+| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive) |
+| `--lock-mode <mode>` | Object Lock mode (`governance` or `compliance`, default `governance`) |
 | `-t, --tenant <id>` | Override tenant ID from config |
 
 **`atlas sharepoint list-snapshots`**

--- a/packages/cli/src/command-object-lock.ts
+++ b/packages/cli/src/command-object-lock.ts
@@ -1,0 +1,76 @@
+import type {
+  ObjectLockMode,
+  ObjectLockPolicy,
+  ObjectLockRequest,
+} from '@wisecom/atlas-types/ports/backup/use-case.port';
+
+/** CLI flags shared by every command that accepts Object Lock options. */
+export interface ObjectLockFlagOptions {
+  retentionDays?: string;
+  lockMode?: string;
+  requireImmutability?: boolean;
+}
+
+/** Builds an ObjectLockRequest from CLI flags; undefined when no retention requested. */
+export function build_object_lock_request(
+  options: ObjectLockFlagOptions,
+): ObjectLockRequest | undefined {
+  const retention_days = parse_retention_days(options.retentionDays);
+  const mode = parse_lock_mode(options.lockMode, retention_days ? 'GOVERNANCE' : undefined);
+  if (!retention_days) {
+    return undefined;
+  }
+
+  return {
+    mode,
+    retention_days,
+  };
+}
+
+/** Builds an ObjectLockPolicy from CLI flags; undefined when no retention requested. */
+export function build_object_lock_policy(
+  options: ObjectLockFlagOptions,
+): ObjectLockPolicy | undefined {
+  const retention_days = parse_retention_days(options.retentionDays);
+  const mode = parse_lock_mode(options.lockMode, retention_days ? 'GOVERNANCE' : undefined);
+  const require_immutability = options.requireImmutability ?? true;
+  if (!retention_days) {
+    return undefined;
+  }
+
+  return {
+    mode,
+    require_immutability,
+    retain_until: compute_retain_until_utc(retention_days),
+  };
+}
+
+/** Parses --lock-mode into an ObjectLockMode, falling back to default_mode. */
+export function parse_lock_mode(
+  raw_mode?: string,
+  default_mode?: ObjectLockMode,
+): ObjectLockMode | undefined {
+  if (!raw_mode) return default_mode;
+  const normalized = raw_mode.trim().toUpperCase();
+  if (normalized === 'GOVERNANCE') return 'GOVERNANCE';
+  if (normalized === 'COMPLIANCE') return 'COMPLIANCE';
+  throw new Error(
+    `Invalid --lock-mode value "${raw_mode}". Expected "governance" or "compliance".`,
+  );
+}
+
+/** Parses --retention-days into a positive integer. */
+export function parse_retention_days(raw_days?: string): number | undefined {
+  if (!raw_days) return undefined;
+  const parsed = parseInt(raw_days, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --retention-days value "${raw_days}". Expected a positive integer.`);
+  }
+  return parsed;
+}
+
+function compute_retain_until_utc(retention_days: number): string {
+  const now = Date.now();
+  const days_ms = retention_days * 24 * 60 * 60 * 1000;
+  return new Date(now + days_ms).toISOString();
+}

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -22,6 +22,7 @@ import { KeyValueList } from '@/ui/components/key-value-list';
 import { ResultSummary, type SummaryEntry } from '@/ui/components/result-summary';
 import { render_static_view } from '@/ui/render';
 import { create_backup_progress } from '@/ui/dashboards/backup-progress-factory';
+import { build_object_lock_request } from '@/command-object-lock';
 
 export interface OneDriveTenantOptions {
   tenant?: string;
@@ -30,6 +31,8 @@ export interface OneDriveTenantOptions {
 export interface OneDriveBackupOptions extends OneDriveTenantOptions {
   owner: string;
   full?: boolean;
+  retentionDays?: string;
+  lockMode?: string;
 }
 
 export interface OneDriveRestoreCommandOptions extends OneDriveTenantOptions {
@@ -110,6 +113,7 @@ export async function execute_onedrive_backup(
     force_full: options.full ?? false,
     owner_email: owner.email,
     owner_display_name: owner.display_name,
+    object_lock_request: build_object_lock_request(options),
     create_progress: create_backup_progress({ rate: 'files/s', extra: 'ver', row_noun: 'drive' }),
   });
 

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -39,6 +39,11 @@ function register_onedrive_backup(group: Command, get_container: ContainerFactor
     .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
     .option('--full', 'force full crawl ignoring saved delta state')
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option(
+      '--retention-days <n>',
+      'apply Object Lock default retention for N days (persists on the bucket)',
+    )
+    .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
     .action((options: OneDriveBackupOptions) => execute_onedrive_backup(get_container(), options));
 }
 

--- a/packages/cli/src/commands/outlook-backup.handler.tsx
+++ b/packages/cli/src/commands/outlook-backup.handler.tsx
@@ -2,16 +2,11 @@ import { Box } from 'ink';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type {
-  BackupUseCase,
-  ObjectLockMode,
-  ObjectLockPolicy,
-  ObjectLockRequest,
-  SyncOptions,
-} from '@wisecom/atlas-types/ports/backup/use-case.port';
+import type { BackupUseCase, SyncOptions } from '@wisecom/atlas-types/ports/backup/use-case.port';
 import type { TenantBackupOrchestrator } from '@wisecom/atlas-types';
 import { BACKUP_USE_CASE_TOKEN, TENANT_ORCHESTRATOR_TOKEN } from '@wisecom/atlas-types';
 import { run_backup_with_cli_adapter } from '@/adapters/backup-operation.adapter';
+import { build_object_lock_policy, build_object_lock_request } from '@/command-object-lock';
 import { run_tenant_backup_with_cli_adapter } from '@/adapters/tenant-backup-operation.adapter';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
@@ -50,62 +45,6 @@ function build_sync_options(options: OutlookBackupOptions): SyncOptions {
     object_lock_request,
     object_lock_policy,
   };
-}
-
-function build_object_lock_request(options: OutlookBackupOptions): ObjectLockRequest | undefined {
-  const retention_days = parse_retention_days(options.retentionDays);
-  const mode = parse_lock_mode(options.lockMode, retention_days ? 'GOVERNANCE' : undefined);
-  if (!retention_days) {
-    return undefined;
-  }
-
-  return {
-    mode,
-    retention_days,
-  };
-}
-
-function build_object_lock_policy(options: OutlookBackupOptions): ObjectLockPolicy | undefined {
-  const retention_days = parse_retention_days(options.retentionDays);
-  const mode = parse_lock_mode(options.lockMode, retention_days ? 'GOVERNANCE' : undefined);
-  const require_immutability = options.requireImmutability ?? true;
-  if (!retention_days) {
-    return undefined;
-  }
-
-  return {
-    mode,
-    require_immutability,
-    retain_until: retention_days ? compute_retain_until_utc(retention_days) : undefined,
-  };
-}
-
-function parse_lock_mode(
-  raw_mode?: string,
-  default_mode?: ObjectLockMode,
-): ObjectLockMode | undefined {
-  if (!raw_mode) return default_mode;
-  const normalized = raw_mode.trim().toUpperCase();
-  if (normalized === 'GOVERNANCE') return 'GOVERNANCE';
-  if (normalized === 'COMPLIANCE') return 'COMPLIANCE';
-  throw new Error(
-    `Invalid --lock-mode value "${raw_mode}". Expected "governance" or "compliance".`,
-  );
-}
-
-function parse_retention_days(raw_days?: string): number | undefined {
-  if (!raw_days) return undefined;
-  const parsed = parseInt(raw_days, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`Invalid --retention-days value "${raw_days}". Expected a positive integer.`);
-  }
-  return parsed;
-}
-
-function compute_retain_until_utc(retention_days: number): string {
-  const now = Date.now();
-  const days_ms = retention_days * 24 * 60 * 60 * 1000;
-  return new Date(now + days_ms).toISOString();
 }
 
 /** Dispatches a backup run for a single mailbox or the entire tenant. */
@@ -169,6 +108,8 @@ async function backup_all_mailboxes(
     concurrency,
     force_full: options.full ?? false,
     page_size,
+    object_lock_request: build_object_lock_request(options),
+    object_lock_policy: build_object_lock_policy(options),
   });
 
   if (result.failed > 0) {

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -22,6 +22,7 @@ import { ErrorList } from '@/ui/components/error-list';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import { ResultSummary, type SummaryEntry } from '@/ui/components/result-summary';
 import { render_static_view } from '@/ui/render';
+import { build_object_lock_request } from '@/command-object-lock';
 
 export interface SharePointTenantOptions {
   tenant?: string;
@@ -30,6 +31,8 @@ export interface SharePointTenantOptions {
 export interface SharePointBackupOptions extends SharePointTenantOptions {
   site: string;
   full?: boolean;
+  retentionDays?: string;
+  lockMode?: string;
 }
 
 export interface SharePointVerifyOptions extends SharePointTenantOptions {
@@ -107,6 +110,7 @@ export async function execute_sharepoint_backup(
     force_full: options.full ?? false,
     site_url: site.site_url,
     site_display_name: site.display_name,
+    object_lock_request: build_object_lock_request(options),
   });
 
   await render_static_view(

--- a/packages/cli/src/commands/sharepoint.command.ts
+++ b/packages/cli/src/commands/sharepoint.command.ts
@@ -53,6 +53,11 @@ function register_sharepoint_backup(group: Command, get_container: ContainerFact
     .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
     .option('--full', 'force full crawl ignoring saved delta state')
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option(
+      '--retention-days <n>',
+      'apply Object Lock default retention for N days (persists on the bucket)',
+    )
+    .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
     .action((options: SharePointBackupOptions) =>
       execute_sharepoint_backup(get_container(), options),
     );

--- a/packages/cli/src/commands/storage-check.command.tsx
+++ b/packages/cli/src/commands/storage-check.command.tsx
@@ -10,6 +10,7 @@ import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import type { KeyValueItem } from '@/ui/components/key-value-list';
 import { render_static_view } from '@/ui/render';
+import { parse_lock_mode, parse_retention_days } from '@/command-object-lock';
 
 type ContainerFactory = () => Container;
 
@@ -99,23 +100,4 @@ function build_request(options: StorageCheckOptions): {
     ...(mode !== undefined ? { mode } : {}),
     ...(retention_days !== undefined ? { retention_days } : {}),
   };
-}
-
-function parse_lock_mode(raw_mode?: string): ObjectLockMode | undefined {
-  if (!raw_mode) return undefined;
-  const normalized = raw_mode.trim().toUpperCase();
-  if (normalized === 'GOVERNANCE') return 'GOVERNANCE';
-  if (normalized === 'COMPLIANCE') return 'COMPLIANCE';
-  throw new Error(
-    `Invalid --lock-mode value "${raw_mode}". Expected "governance" or "compliance".`,
-  );
-}
-
-function parse_retention_days(raw_days?: string): number | undefined {
-  if (!raw_days) return undefined;
-  const parsed = parseInt(raw_days, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`Invalid --retention-days value "${raw_days}". Expected a positive integer.`);
-  }
-  return parsed;
 }

--- a/packages/cli/tests/unit/backup-command.test.ts
+++ b/packages/cli/tests/unit/backup-command.test.ts
@@ -130,4 +130,18 @@ describe('outlook backup command exit code for tenant runs', () => {
 
     expect(process.exitCode).toBeUndefined();
   });
+
+  it('forwards lock flags to the tenant-wide orchestrator run (issue #29)', async () => {
+    mock_run_tenant_backup_with_cli_adapter.mockResolvedValue(make_tenant_result(0));
+
+    await program.parseAsync(
+      ['outlook', 'backup', '--retention-days', '30', '--lock-mode', 'compliance'],
+      { from: 'user' },
+    );
+
+    const tenant_options = mock_run_tenant_backup_with_cli_adapter.mock.calls[0][2];
+    expect(tenant_options.object_lock_request).toEqual({ mode: 'COMPLIANCE', retention_days: 30 });
+    expect(tenant_options.object_lock_policy.mode).toBe('COMPLIANCE');
+    expect(tenant_options.object_lock_policy.retain_until).toBeDefined();
+  });
 });

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -49,6 +49,14 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
     options: OneDriveBackupOptions = {},
   ): Promise<OneDriveBackupResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
+    if (options.object_lock_request?.retention_days) {
+      // Bucket default retention: every new object version (files, versions,
+      // manifests, cursors) inherits the lock - no write path can forget it.
+      await ctx.storage.apply_default_retention(
+        options.object_lock_request.mode ?? 'GOVERNANCE',
+        options.object_lock_request.retention_days,
+      );
+    }
     let progress: BackupProgressReporter | undefined;
     try {
       const previous_cursor =

--- a/packages/onedrive/tests/unit/services/onedrive-backup-retention.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-backup-retention.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { OneDriveBackupService } from '@/services/onedrive-backup.service';
+import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
+
+// Issue #29: OneDrive backups must honour object lock via bucket default
+// retention. The service applies it before scanning; list_drives returning []
+// aborts the run right after, keeping the harness minimal.
+
+function make_harness(): {
+  service: OneDriveBackupService;
+  apply_default_retention: Mock;
+} {
+  const apply_default_retention = vi.fn();
+  const context = {
+    tenant_id: 't',
+    storage: { apply_default_retention },
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+  const connector = { list_drives: vi.fn().mockResolvedValue([]) };
+
+  const service = new OneDriveBackupService(
+    factory,
+    connector as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+  return { service, apply_default_retention };
+}
+
+describe('OneDrive backup object lock (issue #29)', () => {
+  it('applies bucket default retention before scanning', async () => {
+    const { service, apply_default_retention } = make_harness();
+
+    await service
+      .backup_onedrive('t', 'owner-1', {
+        object_lock_request: { mode: 'COMPLIANCE', retention_days: 30 },
+      })
+      .catch(() => undefined); // no drives -> run aborts after retention is applied
+
+    expect(apply_default_retention).toHaveBeenCalledWith('COMPLIANCE', 30);
+  });
+
+  it('defaults to GOVERNANCE mode when only retention days are given', async () => {
+    const { service, apply_default_retention } = make_harness();
+
+    await service
+      .backup_onedrive('t', 'owner-1', { object_lock_request: { retention_days: 7 } })
+      .catch(() => undefined);
+
+    expect(apply_default_retention).toHaveBeenCalledWith('GOVERNANCE', 7);
+  });
+
+  it('leaves the bucket untouched without a lock request', async () => {
+    const { service, apply_default_retention } = make_harness();
+
+    await service.backup_onedrive('t', 'owner-1', {}).catch(() => undefined);
+
+    expect(apply_default_retention).not.toHaveBeenCalled();
+  });
+});

--- a/packages/outlook/src/services/backup/tenant-backup-orchestrator.ts
+++ b/packages/outlook/src/services/backup/tenant-backup-orchestrator.ts
@@ -67,6 +67,8 @@ export class DefaultTenantBackupOrchestrator implements ITenantBackupOrchestrato
           const result = await this._backup.sync_mailbox(tenant_id, mailbox_id, {
             force_full: options.force_full,
             page_size: options.page_size,
+            object_lock_request: options.object_lock_request,
+            object_lock_policy: options.object_lock_policy,
             should_interrupt,
             should_force_stop,
             create_progress: create_mailbox_progress_adapter(slot, progress),

--- a/packages/outlook/tests/unit/tenant-backup-orchestrator.test.ts
+++ b/packages/outlook/tests/unit/tenant-backup-orchestrator.test.ts
@@ -154,4 +154,26 @@ describe('DefaultTenantBackupOrchestrator', () => {
     expect(result.succeeded).toBe(0);
     expect(result.outcomes).toHaveLength(0);
   });
+
+  it('forwards object lock options to every mailbox sync (issue #29)', async () => {
+    const orch = container.get(DefaultTenantBackupOrchestrator);
+    await orch.backup_tenant('t1', {
+      object_lock_request: { mode: 'COMPLIANCE', retention_days: 30 },
+      object_lock_policy: {
+        mode: 'COMPLIANCE',
+        require_immutability: true,
+        retain_until: '2030-01-01T00:00:00.000Z',
+      },
+    });
+
+    const calls = vi.mocked(mock_backup.sync_mailbox).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [, , sync_options] of calls) {
+      expect(sync_options?.object_lock_request).toEqual({
+        mode: 'COMPLIANCE',
+        retention_days: 30,
+      });
+      expect(sync_options?.object_lock_policy?.mode).toBe('COMPLIANCE');
+    }
+  });
 });

--- a/packages/s3/src/adapters/s3-bucket-manager.ts
+++ b/packages/s3/src/adapters/s3-bucket-manager.ts
@@ -4,14 +4,17 @@ import {
   GetObjectLockConfigurationCommand,
   HeadBucketCommand,
   PutBucketLifecycleConfigurationCommand,
+  PutObjectLockConfigurationCommand,
   type ObjectLockEnabled,
   type S3Client,
 } from '@aws-sdk/client-s3';
 import type {
   StorageImmutabilityProbeRequest,
   StorageImmutabilityProbeResult,
+  StorageObjectLockMode,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
+import { ObjectLockUnsupportedError } from '@/adapters/object-lock.errors';
 
 const _checked_buckets = new Set<string>();
 const _immutability_probe_cache = new Map<string, StorageImmutabilityProbeResult>();
@@ -173,4 +176,36 @@ function is_bucket_missing_error(err: unknown): boolean {
     message.includes('bucket does not exist') ||
     status_code === 404
   );
+}
+
+/**
+ * Sets the bucket's Object Lock default retention so every new object version
+ * inherits the lock - immutability as a bucket property that no write path
+ * can forget. Requires a lock-capable bucket; throws
+ * ObjectLockUnsupportedError when the bucket was created without Object Lock
+ * (see the migration runbook in docs/self-hosting/storage.md).
+ */
+export async function apply_bucket_default_retention(
+  client: S3Client,
+  bucket: string,
+  mode: StorageObjectLockMode,
+  retention_days: number,
+): Promise<void> {
+  try {
+    await client.send(
+      new PutObjectLockConfigurationCommand({
+        Bucket: bucket,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: 'Enabled',
+          Rule: { DefaultRetention: { Mode: mode, Days: retention_days } },
+        },
+      }),
+    );
+  } catch (err) {
+    const name = err instanceof Error ? err.name : '';
+    if (name === 'InvalidBucketState' || name === 'ObjectLockConfigurationNotFoundError') {
+      throw new ObjectLockUnsupportedError(bucket);
+    }
+    throw err;
+  }
 }

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -18,9 +18,13 @@ import type {
   MultipartUploadHandle,
   StorageImmutabilityProbeRequest,
   StorageImmutabilityProbeResult,
+  StorageObjectLockMode,
   StorageObjectLockPolicy,
 } from '@wisecom/atlas-types';
-import { probe_bucket_immutability } from '@/adapters/s3-bucket-manager';
+import {
+  apply_bucket_default_retention,
+  probe_bucket_immutability,
+} from '@/adapters/s3-bucket-manager';
 import { S3MultipartUploadHandle } from '@/adapters/s3-multipart-upload-handle';
 import {
   ObjectLockModeRejectedError,
@@ -217,6 +221,14 @@ export class S3ObjectStorage implements ObjectStorage {
     } while (true);
 
     return versions;
+  }
+
+  /** Sets the bucket's Object Lock default retention (see s3-bucket-manager). */
+  async apply_default_retention(
+    mode: StorageObjectLockMode,
+    retention_days: number,
+  ): Promise<void> {
+    await apply_bucket_default_retention(this._client, this._bucket, mode, retention_days);
   }
 
   /** Starts a multipart upload with optional metadata and object lock. */

--- a/packages/s3/tests/unit/s3-object-storage.test.ts
+++ b/packages/s3/tests/unit/s3-object-storage.test.ts
@@ -189,4 +189,28 @@ describe('S3ObjectStorage', () => {
       expect(mock_s3.send).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('apply_default_retention', () => {
+    it('sets bucket default retention with mode and days', async () => {
+      mock_s3.send.mockResolvedValueOnce({});
+
+      await storage.apply_default_retention('COMPLIANCE', 30);
+
+      const cmd = mock_s3.send.mock.calls[0][0];
+      expect(cmd.constructor.name).toBe('PutObjectLockConfigurationCommand');
+      expect(cmd.input.ObjectLockConfiguration.Rule.DefaultRetention).toEqual({
+        Mode: 'COMPLIANCE',
+        Days: 30,
+      });
+    });
+
+    it('maps InvalidBucketState to ObjectLockUnsupportedError', async () => {
+      const err = Object.assign(new Error('no lock'), { name: 'InvalidBucketState' });
+      mock_s3.send.mockRejectedValueOnce(err);
+
+      await expect(storage.apply_default_retention('GOVERNANCE', 7)).rejects.toBeInstanceOf(
+        ObjectLockUnsupportedError,
+      );
+    });
+  });
 });

--- a/packages/sharepoint/src/services/sharepoint-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup.service.ts
@@ -49,6 +49,14 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     options: SharePointBackupOptions = {},
   ): Promise<SharePointBackupResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
+    if (options.object_lock_request?.retention_days) {
+      // Bucket default retention: every new object version (files, versions,
+      // manifests, cursors) inherits the lock - no write path can forget it.
+      await ctx.storage.apply_default_retention(
+        options.object_lock_request.mode ?? 'GOVERNANCE',
+        options.object_lock_request.retention_days,
+      );
+    }
     try {
       const previous_cursor =
         options.force_full === true ? undefined : await this._cursors.load(ctx, site_id);

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-retention.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-retention.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { SharePointBackupService } from '@/services/sharepoint-backup.service';
+import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
+
+// Issue #29: SharePoint backups must honour object lock via bucket default
+// retention. The service applies it before scanning; list_document_libraries
+// returning [] aborts the run right after, keeping the harness minimal.
+
+function make_harness(): {
+  service: SharePointBackupService;
+  apply_default_retention: Mock;
+} {
+  const apply_default_retention = vi.fn();
+  const context = {
+    tenant_id: 't',
+    storage: { apply_default_retention },
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+  const connector = { list_document_libraries: vi.fn().mockResolvedValue([]) };
+
+  const service = new SharePointBackupService(
+    factory,
+    connector as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+  return { service, apply_default_retention };
+}
+
+describe('SharePoint backup object lock (issue #29)', () => {
+  it('applies bucket default retention before scanning', async () => {
+    const { service, apply_default_retention } = make_harness();
+
+    await service
+      .backup_site('t', 'site-1', {
+        object_lock_request: { mode: 'COMPLIANCE', retention_days: 90 },
+      })
+      .catch(() => undefined); // no libraries -> run aborts after retention is applied
+
+    expect(apply_default_retention).toHaveBeenCalledWith('COMPLIANCE', 90);
+  });
+
+  it('leaves the bucket untouched without a lock request', async () => {
+    const { service, apply_default_retention } = make_harness();
+
+    await service.backup_site('t', 'site-1', {}).catch(() => undefined);
+
+    expect(apply_default_retention).not.toHaveBeenCalled();
+  });
+});

--- a/packages/types/src/ports/backup/orchestrator.port.ts
+++ b/packages/types/src/ports/backup/orchestrator.port.ts
@@ -1,10 +1,13 @@
-import type { SyncResult } from '@/ports/backup/use-case.port';
+import type { ObjectLockPolicy, ObjectLockRequest, SyncResult } from '@/ports/backup/use-case.port';
 import type { TenantProgressReporter } from '@/ports/backup/tenant-progress.port';
 
 export interface TenantBackupOptions {
   concurrency?: number;
   force_full?: boolean;
   page_size?: number;
+  /** Object Lock retention request applied to every mailbox in the run. */
+  object_lock_request?: ObjectLockRequest;
+  object_lock_policy?: ObjectLockPolicy;
   progress?: TenantProgressReporter;
   should_interrupt?: () => boolean;
   should_force_stop?: () => boolean;

--- a/packages/types/src/ports/onedrive/use-case.port.ts
+++ b/packages/types/src/ports/onedrive/use-case.port.ts
@@ -2,7 +2,7 @@ import type {
   OneDriveFileVersionRecord,
   OneDriveSnapshotManifest,
 } from '../../domain/onedrive-manifest';
-import type { BackupProgressReporter } from '../backup/use-case.port';
+import type { BackupProgressReporter, ObjectLockRequest } from '../backup/use-case.port';
 
 export interface OneDriveBackupSummary {
   readonly drives_scanned: number;
@@ -29,6 +29,12 @@ export interface OneDriveBackupOptions {
   readonly force_full?: boolean | undefined;
   readonly owner_email?: string | undefined;
   readonly owner_display_name?: string | undefined;
+  /**
+   * Object Lock retention applied as the bucket's default retention before
+   * the run: every new object version (files, versions, manifests, cursors)
+   * inherits the lock. Persists on the bucket for subsequent writes.
+   */
+  readonly object_lock_request?: ObjectLockRequest | undefined;
   /**
    * CLI presenter hook: builds a per-drive progress reporter before the scan
    * starts. Drive totals arrive via `set_row_total` once each delta is fetched.

--- a/packages/types/src/ports/sharepoint/use-case.port.ts
+++ b/packages/types/src/ports/sharepoint/use-case.port.ts
@@ -2,6 +2,7 @@ import type {
   SharePointFileVersionRecord,
   SharePointSnapshotManifest,
 } from '../../domain/sharepoint-manifest';
+import type { ObjectLockRequest } from '../backup/use-case.port';
 
 export interface SharePointBackupSummary {
   readonly libraries_scanned: number;
@@ -28,6 +29,12 @@ export interface SharePointBackupOptions {
   readonly force_full?: boolean | undefined;
   readonly site_url?: string | undefined;
   readonly site_display_name?: string | undefined;
+  /**
+   * Object Lock retention applied as the bucket's default retention before
+   * the run: every new object version (files, versions, manifests, cursors)
+   * inherits the lock. Persists on the bucket for subsequent writes.
+   */
+  readonly object_lock_request?: ObjectLockRequest | undefined;
 }
 
 export interface SharePointBackupUseCase {

--- a/packages/types/src/ports/storage/object-storage.port.ts
+++ b/packages/types/src/ports/storage/object-storage.port.ts
@@ -79,6 +79,14 @@ export interface ObjectStorage {
     request?: StorageImmutabilityProbeRequest,
   ): Promise<StorageImmutabilityProbeResult>;
 
+  /**
+   * Sets the bucket's Object Lock default retention: every new object version
+   * inherits the lock automatically, so no write path can forget it. Persists
+   * on the bucket until replaced. Requires a lock-capable bucket (rejects
+   * otherwise).
+   */
+  apply_default_retention(mode: StorageObjectLockMode, retention_days: number): Promise<void>;
+
   /** Starts a multipart upload, returning a handle for part-level control. */
   begin_multipart_upload(
     key: string,


### PR DESCRIPTION
Fixes #29.

Two gaps made WORM protection much narrower than advertised:

1. **Tenant-wide Outlook silently dropped `--retention-days`/`--lock-mode`** — `TenantBackupOptions` had no lock fields. Now carries `object_lock_request`/`object_lock_policy`, forwarded by the orchestrator to every mailbox sync.
2. **OneDrive/SharePoint never applied Object Lock** — fixed via **bucket default retention** (`PutObjectLockConfiguration`) per the issue comment, instead of threading a policy through every processor/pipeline/repository: the bucket stamps the lock on every new object version, so no write path can forget it (which is exactly how this bug happened). `onedrive backup`/`sharepoint backup` gain `--retention-days`/`--lock-mode`; lock-incapable buckets fail fast with `ObjectLockUnsupportedError`.

Also: CLI parse helpers deduplicated into `command-object-lock.ts` (were triplicated); `apply_default_retention` implementation lives in `s3-bucket-manager` beside the immutability probe.

**Deferred to #30** (per the "one unit" comment, seam = retention application vs bucket capability): lock-capable bucket creation, lifecycle rules, storage-check tri-state, migration runbook.

**Tests** (all red on unfixed code): CLI tenant-wide forwarding, orchestrator per-mailbox forwarding, drive services apply-before-scan + GOVERNANCE default + no-op without flags, adapter mapping + error translation. Suites: outlook 176, onedrive 44, sharepoint 88, s3 41, cli 42; lint + docs clean. Full recap on the issue.