### PR TITLE
fix(s3): create tenant buckets lock-capable with working lifecycle rules

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -500,7 +500,7 @@ Application permissions `Sites.Read.All` and `Files.Read.All` are required for S
 
 ## `atlas storage-check`
 
-Validate immutable backup readiness without running a backup. Reports versioning and Object Lock status.
+Validate immutable backup readiness without running a backup. Reports versioning, Object Lock status, and the bucket class: `lock-capable` (can take retention policies), `versioned-only (legacy)`, or `unversioned (legacy)` -- legacy classes mean the bucket predates v2.1.0 auto-provisioning and needs the [migration runbook](/self-hosting/storage#migrating-a-legacy-bucket-to-object-lock) before immutability can be used. Exits non-zero when the bucket is not lock-ready, so it can gate scheduled jobs.
 
 ```bash
 atlas storage-check

--- a/docs/self-hosting/storage.md
+++ b/docs/self-hosting/storage.md
@@ -2,6 +2,29 @@
 
 Atlas stores backups in any S3-compatible object storage. For self-hosted deployments, MinIO running in Docker is the recommended option.
 
+
+## Bucket Provisioning and Object Lock
+
+Atlas creates each tenant's bucket automatically on first backup (`atlas-{tenant_id}`), and since v2.1.0 creates it **lock-capable**: `CreateBucket` is issued with `ObjectLockEnabledForBucket: true`, which also enables versioning. This is deliberate front-loading -- on both AWS S3 and MinIO, Object Lock can only be enabled at bucket creation (AWS requires a support ticket to retrofit it; MinIO refuses outright). A lock-capable bucket without a retention policy behaves exactly like a normal versioned bucket, so this changes nothing until you opt into immutability with `--retention-days` on a backup command.
+
+New buckets also receive housekeeping lifecycle rules: incomplete multipart uploads are aborted after 7 days, orphaned delete markers are removed, and noncurrent object versions expire after 30 days (versioning means overwritten delta cursors and indexes leave stale versions behind; Atlas never reads them -- its file version history is stored as first-class objects, not S3 versions).
+
+Backends that reject `ObjectLockEnabledForBucket` get a plain bucket and a loud warning at creation time; immutability will not work there.
+
+Run `atlas storage-check` to see which class a tenant's bucket is: `lock-capable`, `versioned-only (legacy)`, or `unversioned (legacy)`.
+
+### Migrating a Legacy Bucket to Object Lock
+
+Buckets created before v2.1.0 are not lock-capable and cannot be upgraded in place. The migration is a tenant-by-tenant re-pointing, using Atlas's own replication machinery:
+
+1. **Create a lock-capable target bucket** manually: `aws s3api create-bucket --bucket atlas-{tenant}-v2 --object-lock-enabled-for-bucket` (MinIO: `mc mb --with-lock`).
+2. **Replicate the tenant** into it: `atlas replicate --tenant <id>` with the target configured as the replication destination -- this copies the DEK first, then all snapshots, and verifies checksums. (Plain `aws s3 sync` also works; the DEK object `_meta/dek.enc` must be copied as-is.)
+3. **Repoint the tenant** at the new bucket (rename or alias so `atlas-{tenant_id}` resolves to the new bucket, e.g. delete the old bucket and rename via a final sync).
+4. **Verify**: `atlas storage-check -t <id>` should report `lock-capable`; run `atlas verify` for content integrity.
+5. **Decommission** the old bucket once a full backup cycle has succeeded against the new one.
+
+Until migrated, backups to legacy buckets keep working -- only `--retention-days` immutability is unavailable (the backup fails fast with `ObjectLockUnsupportedError` rather than pretending to be immutable).
+
 ## Storage Backend: MinIO on Docker
 
 The included `docker/docker-compose.yml` starts MinIO with a Docker named volume:

--- a/packages/cli/src/commands/storage-check.command.tsx
+++ b/packages/cli/src/commands/storage-check.command.tsx
@@ -60,11 +60,13 @@ async function execute_storage_check(
 }
 
 function build_result_items(result: StorageCheckResult, ready: boolean): KeyValueItem[] {
+  const bucket_class = classify_bucket(result);
   const items: KeyValueItem[] = [
     { label: 'Bucket', value: result.bucket },
     { label: 'Reachable', value: result.reachable ? 'yes' : 'no' },
     { label: 'Versioning', value: result.versioning_enabled ? 'enabled' : 'disabled' },
     { label: 'Object Lock', value: result.object_lock_enabled ? 'enabled' : 'disabled' },
+    { label: 'Bucket class', value: bucket_class.label, color: bucket_class.color },
     { label: 'Governance mode', value: result.mode_supported ? 'supported' : 'unsupported' },
     { label: 'Compliance mode', value: result.mode_supported ? 'supported' : 'unsupported' },
   ];
@@ -83,6 +85,17 @@ function build_result_items(result: StorageCheckResult, ready: boolean): KeyValu
     color: ready ? 'green' : 'red',
   });
   return items;
+}
+
+/**
+ * Classifies the bucket for operators: lock-capable buckets can take
+ * retention policies, versioned-only and unversioned ones are legacy
+ * (pre-#30) and need the migration runbook in docs/self-hosting/storage.md.
+ */
+function classify_bucket(result: StorageCheckResult): { label: string; color: string } {
+  if (result.object_lock_enabled) return { label: 'lock-capable', color: 'green' };
+  if (result.versioning_enabled) return { label: 'versioned-only (legacy)', color: 'yellow' };
+  return { label: 'unversioned (legacy)', color: 'red' };
 }
 
 function resolve_tenant_id(container: Container, options: StorageCheckOptions): string {

--- a/packages/s3/src/adapters/s3-bucket-manager.ts
+++ b/packages/s3/src/adapters/s3-bucket-manager.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   CreateBucketCommand,
   GetBucketVersioningCommand,
@@ -21,9 +22,14 @@ const _immutability_probe_cache = new Map<string, StorageImmutabilityProbeResult
 
 /**
  * Ensures a bucket exists, creating it if necessary.
- * New buckets get best-effort housekeeping lifecycle rules (abort incomplete
- * multipart uploads, clean up expired delete markers). Existing buckets are
- * left untouched. Caches results in-process so subsequent calls are free.
+ * New buckets are created lock-capable (`ObjectLockEnabledForBucket: true`,
+ * which implies versioning): on AWS and MinIO this is only possible at
+ * creation time, and a lock-capable bucket without a retention config
+ * behaves exactly like a normal versioned bucket -- it merely keeps the
+ * immutability door open (issue #30). Backends that reject the flag get a
+ * plain bucket with a loud warning. New buckets also get best-effort
+ * housekeeping lifecycle rules. Existing buckets are left untouched.
+ * Caches results in-process so subsequent calls are free.
  */
 export async function ensure_bucket_exists(
   client: S3Client,
@@ -34,11 +40,41 @@ export async function ensure_bucket_exists(
 
   const exists = await bucket_exists(client, bucket);
   if (!exists) {
-    await client.send(new CreateBucketCommand({ Bucket: bucket }));
+    await create_lock_capable_bucket(client, bucket);
     await apply_default_lifecycle(client, bucket);
   }
 
   _checked_buckets.add(bucket);
+}
+
+/**
+ * Creates a bucket with Object Lock enabled, falling back to a plain bucket
+ * only when the backend rejects the capability itself. The fallback warning
+ * matters: a plain bucket can never gain Object Lock later (AWS requires a
+ * support ticket, MinIO refuses outright) -- see the legacy-bucket migration
+ * runbook in docs/self-hosting/storage.md.
+ */
+async function create_lock_capable_bucket(client: S3Client, bucket: string): Promise<void> {
+  try {
+    await client.send(
+      new CreateBucketCommand({ Bucket: bucket, ObjectLockEnabledForBucket: true }),
+    );
+  } catch (err) {
+    if (!is_lock_flag_rejection(err)) throw err;
+    logger.warn(
+      `Backend rejected Object Lock at creation for bucket "${bucket}" -- created without it. ` +
+        `Immutability (--retention-days) will not work on this bucket.`,
+    );
+    await client.send(new CreateBucketCommand({ Bucket: bucket }));
+  }
+}
+
+/** True when the error signals the backend cannot honour ObjectLockEnabledForBucket. */
+function is_lock_flag_rejection(err: unknown): boolean {
+  const name = (err as { name?: string }).name ?? '';
+  // ponytail: name list covers AWS-compatible backends seen in the wild;
+  // extend if a new backend rejects the flag with a different code.
+  return ['NotImplemented', 'InvalidArgument', 'InvalidRequest', 'MalformedXML'].includes(name);
 }
 
 /** Probes whether a bucket already exists and is accessible. */
@@ -55,36 +91,61 @@ async function bucket_exists(client: S3Client, bucket: string): Promise<boolean>
 
 /**
  * Best-effort housekeeping lifecycle rules for Atlas-created buckets:
- *  1. Abort incomplete multipart uploads after 7 days.
- *  2. Remove delete markers that no longer reference any version.
- * These are safe on both AWS S3 and MinIO. Failures are logged but not fatal.
+ *  1. Abort incomplete multipart uploads after 7 days and remove delete
+ *     markers that no longer reference any version (one combined rule:
+ *     MinIO rejects a rule whose only action is
+ *     AbortIncompleteMultipartUpload -- verified against a live MinIO).
+ *  2. Expire noncurrent versions after 30 days -- versioning is now on by
+ *     default (Object Lock implies it), so overwritten cursors/indexes would
+ *     otherwise accumulate stale versions forever. Atlas never reads
+ *     noncurrent versions; its own version history is stored as first-class
+ *     objects. Locked versions are simply retained until their lock expires.
+ * The request carries an explicit Content-MD5: MinIO requires it on
+ * lifecycle puts and AWS SDK >= 3.729 no longer sends it by default.
+ * Failures are logged but not fatal.
  */
 async function apply_default_lifecycle(client: S3Client, bucket: string): Promise<void> {
-  try {
-    await client.send(
-      new PutBucketLifecycleConfigurationCommand({
-        Bucket: bucket,
-        LifecycleConfiguration: {
-          Rules: [
-            {
-              ID: 'atlas-abort-incomplete-uploads',
-              Status: 'Enabled',
-              Filter: {},
-              AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
-            },
-            {
-              ID: 'atlas-cleanup-delete-markers',
-              Status: 'Enabled',
-              Filter: {},
-              Expiration: { ExpiredObjectDeleteMarker: true },
-            },
-          ],
+  const command = new PutBucketLifecycleConfigurationCommand({
+    Bucket: bucket,
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: 'atlas-housekeeping',
+          Status: 'Enabled',
+          Filter: { Prefix: '' },
+          AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
+          Expiration: { ExpiredObjectDeleteMarker: true },
         },
-      }),
-    );
-  } catch {
-    logger.debug(`Could not configure lifecycle rules on bucket "${bucket}" (best-effort).`);
+        {
+          ID: 'atlas-expire-noncurrent-versions',
+          Status: 'Enabled',
+          Filter: { Prefix: '' },
+          NoncurrentVersionExpiration: { NoncurrentDays: 30 },
+        },
+      ],
+    },
+  });
+  add_content_md5(command);
+
+  try {
+    await client.send(command);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`Could not configure lifecycle rules on bucket "${bucket}" (best-effort): ${msg}`);
   }
+}
+
+/** Injects a Content-MD5 header computed over the serialized request body. */
+function add_content_md5(command: PutBucketLifecycleConfigurationCommand): void {
+  command.middlewareStack.add(
+    (next) => async (args) => {
+      const request = (args as { request: { body: string; headers: Record<string, string> } })
+        .request;
+      request.headers['content-md5'] = createHash('md5').update(request.body).digest('base64');
+      return next(args);
+    },
+    { step: 'build', name: 'atlasContentMd5' },
+  );
 }
 
 /** Clears the in-process bucket cache (useful for testing). */

--- a/packages/s3/tests/unit/s3-bucket-manager.test.ts
+++ b/packages/s3/tests/unit/s3-bucket-manager.test.ts
@@ -17,7 +17,7 @@ describe('s3-bucket-manager', () => {
     reset_bucket_cache();
   });
 
-  it('creates bucket with housekeeping lifecycle rules when it does not exist', async () => {
+  it('creates lock-capable buckets with housekeeping lifecycle rules (issue #30)', async () => {
     mock_s3.send
       .mockRejectedValueOnce(Object.assign(new Error(), { name: 'NotFound' }))
       .mockResolvedValueOnce({})
@@ -28,13 +28,39 @@ describe('s3-bucket-manager', () => {
     expect(mock_s3.send).toHaveBeenCalledTimes(3);
     const create_cmd = mock_s3.send.mock.calls[1][0];
     expect(create_cmd.input.Bucket).toBe('new-bucket');
+    expect(create_cmd.input.ObjectLockEnabledForBucket).toBe(true);
     const lifecycle_cmd = mock_s3.send.mock.calls[2][0];
     expect(lifecycle_cmd.input.Bucket).toBe('new-bucket');
     const rules = lifecycle_cmd.input.LifecycleConfiguration.Rules;
     expect(rules).toHaveLength(2);
+    // Combined rule: MinIO rejects AbortIncompleteMultipartUpload as a sole action
     expect(rules[0].AbortIncompleteMultipartUpload).toEqual({ DaysAfterInitiation: 7 });
-    expect(rules[0].NoncurrentVersionExpiration).toBeUndefined();
-    expect(rules[1].Expiration?.ExpiredObjectDeleteMarker).toBe(true);
+    expect(rules[0].Expiration?.ExpiredObjectDeleteMarker).toBe(true);
+    expect(rules[1].NoncurrentVersionExpiration).toEqual({ NoncurrentDays: 30 });
+  });
+
+  it('falls back to a plain bucket when the backend rejects Object Lock at creation', async () => {
+    mock_s3.send
+      .mockRejectedValueOnce(Object.assign(new Error(), { name: 'NotFound' }))
+      .mockRejectedValueOnce(Object.assign(new Error(), { name: 'NotImplemented' }))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await ensure_bucket_exists(mock_s3 as never, 'plain-bucket');
+
+    expect(mock_s3.send).toHaveBeenCalledTimes(4);
+    const retry_cmd = mock_s3.send.mock.calls[2][0];
+    expect(retry_cmd.input.Bucket).toBe('plain-bucket');
+    expect(retry_cmd.input.ObjectLockEnabledForBucket).toBeUndefined();
+  });
+
+  it('rethrows creation errors that are not a lock-capability rejection', async () => {
+    mock_s3.send
+      .mockRejectedValueOnce(Object.assign(new Error(), { name: 'NotFound' }))
+      .mockRejectedValueOnce(Object.assign(new Error('denied'), { name: 'AccessDenied' }));
+
+    await expect(ensure_bucket_exists(mock_s3 as never, 'forbidden')).rejects.toThrow('denied');
+    expect(mock_s3.send).toHaveBeenCalledTimes(2);
   });
 
   it('swallows lifecycle errors on unsupported backends', async () => {


### PR DESCRIPTION
Fixes #30.

Auto-created tenant buckets used a bare `CreateBucketCommand` — permanently lock-incapable on AWS/MinIO, making immutability unusable on every organically-created bucket.

- **Lock-capable by default**: `ObjectLockEnabledForBucket: true` (implies versioning); safe — behaves like a plain versioned bucket until retention is opted into (#29). Rejecting backends fall back to a plain bucket with a loud warning.
- **Lifecycle rules now actually apply** — live-MinIO smoke exposed two pre-existing silent failures: missing `Content-MD5` (required by MinIO, dropped by SDK ≥3.729 → build middleware) and `AbortIncompleteMultipartUpload` as a sole action (MinIO schema rejection → merged with delete-marker rule). Added `NoncurrentVersionExpiration(30d)` for versioning-by-default churn.
- **storage-check tri-state**: `lock-capable` / `versioned-only (legacy)` / `unversioned (legacy)`.
- **Docs**: bucket provisioning + legacy migration runbook.

**Proof**: live MinIO end-to-end — fresh auto-provisioned bucket → lock-capable + versioned → lifecycle round-trips → default retention → write inherits GOVERNANCE lock → locked-version delete refused. Unit tests red on unfixed code; s3 48 + cli 41 green; lint + docs clean. Recap on the issue.