### PR TITLE
fix(cli): non-zero exit and error listing for partial backups

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,8 +54,11 @@ atlas outlook backup --full                                    # force full sync
 | `--require-immutability` | Fail if immutability cannot be enforced                        |
 | `-t, --tenant <id>`      | Override tenant ID from config                                 |
 
+::: warning Exit codes (all backup commands: Outlook, OneDrive, SharePoint)
+`0` -- complete: every folder/file/mailbox processed without error. `1` -- hard failure: the run aborted (auth, storage, unhandled error). `2` -- **partial**: a snapshot was saved but the run is incomplete -- per-folder/per-file errors, failed mailboxes in a tenant run, or a soft interrupt (Ctrl+C). Failed items are listed on stderr. Schedulers should treat `1` as "page me" and `2` as "warn me": a partial backup is restorable but is missing the listed items. A run is reported complete only when every error bucket is empty (corso's fault-model contract).
+:::
 ::: tip Tenant-wide mode
-When no `-m` flag is given, Atlas discovers all Exchange Online-licensed and shared mailboxes via Microsoft Graph, then runs up to `-C` concurrent backup workers. Shared mailboxes are detected via the Graph `mailboxSettings.userPurpose` property; unlicensed users that are not shared mailboxes are skipped because Graph rejects their mail endpoints. A compact dashboard shows each active worker's mailbox, folder progress, and overall completion. The first Ctrl+C gracefully finishes active mailboxes; a second Ctrl+C force-quits immediately. Failures are isolated per mailbox -- one failing mailbox never aborts the others -- but the command exits non-zero when any mailbox failed, so schedulers and monitoring can detect partial backups instead of treating them as clean runs.
+When no `-m` flag is given, Atlas discovers all Exchange Online-licensed and shared mailboxes via Microsoft Graph, then runs up to `-C` concurrent backup workers. Shared mailboxes are detected via the Graph `mailboxSettings.userPurpose` property; unlicensed users that are not shared mailboxes are skipped because Graph rejects their mail endpoints. A compact dashboard shows each active worker's mailbox, folder progress, and overall completion. The first Ctrl+C gracefully finishes active mailboxes; a second Ctrl+C force-quits immediately. Failures are isolated per mailbox -- one failing mailbox never aborts the others -- but the command exits `2` (partial) and lists the failed mailboxes when any of them failed, so schedulers and monitoring can detect partial backups instead of treating them as clean runs.
 :::
 
 ::: details Page size tuning

--- a/packages/cli/src/command-run-outcome.ts
+++ b/packages/cli/src/command-run-outcome.ts
@@ -1,0 +1,42 @@
+import { logger } from '@wisecom/atlas-core';
+
+/**
+ * Exit code for a run that produced a snapshot but is incomplete (per-item
+ * errors or an interrupt). Distinct from 1 (hard failure) so schedulers can
+ * separate "page me" from "warn me". Corso's fault model: a backup is
+ * complete only when every error bucket is empty.
+ */
+export const EXIT_PARTIAL = 2;
+
+export interface RunOutcome {
+  readonly errors: readonly string[];
+  readonly warnings: readonly string[];
+  readonly interrupted?: boolean;
+}
+
+/**
+ * Prints per-item errors/warnings on stderr and sets the partial exit code
+ * when the run is incomplete. Shared by Outlook, OneDrive, and SharePoint
+ * backup commands so all three domains report identically. Hard failures
+ * throw and exit 1 upstream; this only handles the partial bucket.
+ */
+export function report_run_outcome(outcome: RunOutcome, item_noun: string): void {
+  for (const warning of outcome.warnings) {
+    logger.warn(`  ${warning}`);
+  }
+  for (const error of outcome.errors) {
+    logger.error(`  ${item_noun} error: ${error}`);
+  }
+
+  if (outcome.interrupted) {
+    logger.warn('Run interrupted before all items were processed');
+  }
+
+  if (outcome.errors.length > 0 || outcome.interrupted === true) {
+    const suffix = outcome.interrupted === true ? ' (interrupted)' : '';
+    logger.error(
+      `Backup incomplete: ${outcome.errors.length} ${item_noun} error(s)${suffix} -- exit ${EXIT_PARTIAL}`,
+    );
+    process.exitCode = EXIT_PARTIAL;
+  }
+}

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -23,6 +23,7 @@ import { ResultSummary, type SummaryEntry } from '@/ui/components/result-summary
 import { render_static_view } from '@/ui/render';
 import { create_backup_progress } from '@/ui/dashboards/backup-progress-factory';
 import { build_object_lock_request } from '@/command-object-lock';
+import { report_run_outcome } from '@/command-run-outcome';
 
 export interface OneDriveTenantOptions {
   tenant?: string;
@@ -139,19 +140,12 @@ export async function execute_onedrive_backup(
     );
   }
 
-  for (const w of result.summary.warnings) {
-    logger.warn(w);
-  }
-
   if (result.summary.healthy) {
     logger.success('Status: HEALTHY');
   } else {
     logger.error('Status: UNHEALTHY');
-    await render_static_view(
-      <ErrorList errors={result.summary.errors} max={result.summary.errors.length} />,
-    );
-    process.exitCode = 1;
   }
+  report_run_outcome({ errors: result.summary.errors, warnings: result.summary.warnings }, 'file');
 }
 
 export async function execute_onedrive_restore(

--- a/packages/cli/src/commands/outlook-backup.handler.tsx
+++ b/packages/cli/src/commands/outlook-backup.handler.tsx
@@ -9,6 +9,7 @@ import { run_backup_with_cli_adapter } from '@/adapters/backup-operation.adapter
 import { build_object_lock_policy, build_object_lock_request } from '@/command-object-lock';
 import { run_tenant_backup_with_cli_adapter } from '@/adapters/tenant-backup-operation.adapter';
 import { format_bytes } from '@/command-formatters';
+import { report_run_outcome } from '@/command-run-outcome';
 import { logger } from '@wisecom/atlas-core';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -90,6 +91,14 @@ async function backup_single_mailbox(
       `${result.manifest.total_objects} objects, ` +
       format_bytes(result.manifest.total_size_bytes),
   );
+  report_run_outcome(
+    {
+      errors: result.summary.folder_errors,
+      warnings: result.summary.warnings,
+      interrupted: result.summary.interrupted,
+    },
+    'folder',
+  );
 }
 
 /** Runs full-tenant backup via the orchestrator with CLI dashboard. */
@@ -112,8 +121,19 @@ async function backup_all_mailboxes(
     object_lock_policy: build_object_lock_policy(options),
   });
 
-  if (result.failed > 0) {
-    logger.error(`Tenant backup finished with ${result.failed} failed mailbox(es)`);
-    process.exitCode = 1;
-  }
+  const mailbox_errors = result.outcomes
+    .filter((o) => o.error !== undefined)
+    .map((o) => `${o.owner_id}: ${o.error}`);
+  report_run_outcome(
+    {
+      // Outcomes can be truncated on hard stops; the failed counter is authoritative.
+      errors:
+        result.failed > 0 && mailbox_errors.length === 0
+          ? [`${result.failed} mailbox(es) failed`]
+          : mailbox_errors,
+      warnings: [],
+      interrupted: result.interrupted,
+    },
+    'mailbox',
+  );
 }

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -23,6 +23,7 @@ import { KeyValueList } from '@/ui/components/key-value-list';
 import { ResultSummary, type SummaryEntry } from '@/ui/components/result-summary';
 import { render_static_view } from '@/ui/render';
 import { build_object_lock_request } from '@/command-object-lock';
+import { report_run_outcome } from '@/command-run-outcome';
 
 export interface SharePointTenantOptions {
   tenant?: string;
@@ -147,19 +148,12 @@ export async function execute_sharepoint_backup(
     );
   }
 
-  for (const w of result.summary.warnings) {
-    logger.warn(w);
-  }
-
   if (result.summary.healthy) {
     logger.success('Status: HEALTHY');
   } else {
     logger.error('Status: UNHEALTHY');
-    await render_static_view(
-      <ErrorList errors={result.summary.errors} max={result.summary.errors.length} />,
-    );
-    process.exitCode = 1;
   }
+  report_run_outcome({ errors: result.summary.errors, warnings: result.summary.warnings }, 'file');
 }
 
 export async function execute_sharepoint_restore(

--- a/packages/cli/tests/unit/backup-command.test.ts
+++ b/packages/cli/tests/unit/backup-command.test.ts
@@ -20,12 +20,25 @@ vi.mock('@/adapters/tenant-backup-operation.adapter', () => ({
 
 function make_tenant_result(failed: number): Record<string, unknown> {
   return {
-    outcomes: [],
+    outcomes: failed > 0 ? [{ owner_id: 'broken@t.com', error: 'Graph 503' }] : [],
     total_mailboxes: 2,
     succeeded: 2 - failed,
     failed,
     interrupted: false,
     elapsed_ms: 100,
+  };
+}
+
+function make_sync_result(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    snapshot: { id: 'snap-1' },
+    manifest: { total_objects: 1, total_size_bytes: 10 },
+    summary: {
+      folder_errors: [],
+      warnings: [],
+      interrupted: false,
+      ...overrides,
+    },
   };
 }
 
@@ -45,10 +58,7 @@ describe('outlook backup command immutability options', () => {
     program = new Command();
     register_outlook_command(program, () => container);
     mock_run_backup_with_cli_adapter.mockReset();
-    mock_run_backup_with_cli_adapter.mockResolvedValue({
-      snapshot: { id: 'snap-1' },
-      manifest: { total_objects: 1, total_size_bytes: 10 },
-    });
+    mock_run_backup_with_cli_adapter.mockResolvedValue(make_sync_result());
   });
 
   it('resolves retention-days into retain_until and maps governance mode', async () => {
@@ -115,12 +125,12 @@ describe('outlook backup command exit code for tenant runs', () => {
     process.exitCode = exit_code_before;
   });
 
-  it('sets a failing exit code when any mailbox backup failed', async () => {
+  it('exits 2 (partial) and names the mailbox when any mailbox backup failed (issue #32)', async () => {
     mock_run_tenant_backup_with_cli_adapter.mockResolvedValue(make_tenant_result(1));
 
     await program.parseAsync(['outlook', 'backup'], { from: 'user' });
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 
   it('keeps a clean exit code when all mailbox backups succeed', async () => {
@@ -143,5 +153,53 @@ describe('outlook backup command exit code for tenant runs', () => {
     expect(tenant_options.object_lock_request).toEqual({ mode: 'COMPLIANCE', retention_days: 30 });
     expect(tenant_options.object_lock_policy.mode).toBe('COMPLIANCE');
     expect(tenant_options.object_lock_policy.retain_until).toBeDefined();
+  });
+});
+
+describe('outlook backup single-mailbox exit code (issue #32)', () => {
+  let container: Container;
+  let program: Command;
+  let exit_code_before: string | number | undefined;
+
+  beforeEach(() => {
+    container = new Container();
+    container.bind(BACKUP_USE_CASE_TOKEN).toConstantValue({ sync_mailbox: vi.fn() });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-from-config' });
+
+    program = new Command();
+    register_outlook_command(program, () => container);
+    mock_run_backup_with_cli_adapter.mockReset();
+    exit_code_before = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = exit_code_before;
+  });
+
+  it('exits 2 when any folder failed even though a snapshot was saved', async () => {
+    mock_run_backup_with_cli_adapter.mockResolvedValue(
+      make_sync_result({ folder_errors: ['Inbox: Graph timeout'] }),
+    );
+
+    await program.parseAsync(['outlook', 'backup', '-m', 'user@t.com'], { from: 'user' });
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('exits 2 when the run was interrupted', async () => {
+    mock_run_backup_with_cli_adapter.mockResolvedValue(make_sync_result({ interrupted: true }));
+
+    await program.parseAsync(['outlook', 'backup', '-m', 'user@t.com'], { from: 'user' });
+
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('keeps a clean exit code on a fully successful run', async () => {
+    mock_run_backup_with_cli_adapter.mockResolvedValue(make_sync_result());
+
+    await program.parseAsync(['outlook', 'backup', '-m', 'user@t.com'], { from: 'user' });
+
+    expect(process.exitCode).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #32.

Single-mailbox backup printed success and exited 0 even when every folder failed — scheduled backups silently incomplete.

- **Corso fault-model contract** via one shared `command-run-outcome.ts` helper, identical across Outlook / OneDrive / SharePoint: `0` complete, `1` hard failure, `2` partial (snapshot saved but folder/file errors, failed mailboxes, or soft interrupt) — failed items on stderr.
- Tenant-wide moves from exit 1 → 2 for partial (schedulers can distinguish 'page me' from 'warn me'); failed counter authoritative under truncated outcomes.
- Drive handlers had exit 1 on unhealthy already — now aligned to the same taxonomy/reporting.
- Skipped `--fail-fast` (needs a sync-service stop signal; own change) — rationale on issue.

**Proof**: acceptance test pinned (folder error → exit 2 + stderr listing); 3 new tests red on unfixed code. cli 44, core 213, outlook 180 green; lint + docs clean. Recap on issue.