### PR TITLE
fix(graph): scope retry timeout to single requests, not enumerations

### DIFF
--- a/packages/m365-graph/src/graph-error-helpers.ts
+++ b/packages/m365-graph/src/graph-error-helpers.ts
@@ -17,6 +17,19 @@ const BASE_DELAY_MS = 1_000;
 const MAX_DELAY_MS = 300_000;
 const REQUEST_TIMEOUT_MS = 60_000;
 
+export interface GraphRetryOptions {
+  /**
+   * Per-attempt timeout. The default 60s bounds a single Graph request --
+   * NEVER wrap a multi-page enumeration in one with_graph_retry call: the
+   * timeout races the whole loop, restarts it from page 1 on expiry, and the
+   * losing arm keeps consuming Graph quota (issue #33). Retry per page so the
+   * paginator resumes from @odata.nextLink. Large single-object transfers
+   * (attachment $value, file content) should pass a bigger window -- corso
+   * converged on 1h default / 48h for large files against production tenants.
+   */
+  readonly timeout_ms?: number;
+}
+
 /**
  * Detects Graph errors that indicate an invalid/expired delta token.
  * Matches Corso's pattern: syncStateNotFound, resyncRequired, syncStateInvalid.
@@ -128,10 +141,14 @@ export function is_retryable_error(err: unknown): boolean {
  * This function is designed to be reusable across backup, restore, save, and
  * any other operation that communicates over the network.
  */
-export async function with_graph_retry<T>(fn: () => Promise<T>): Promise<T> {
+export async function with_graph_retry<T>(
+  fn: () => Promise<T>,
+  options: GraphRetryOptions = {},
+): Promise<T> {
+  const timeout_ms = options.timeout_ms ?? REQUEST_TIMEOUT_MS;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      return await race_timeout(fn(), REQUEST_TIMEOUT_MS);
+      return await race_timeout(fn(), timeout_ms);
     } catch (err) {
       if (!is_retryable_error(err) || attempt === MAX_RETRIES) throw err;
 
@@ -159,8 +176,7 @@ function extract_retry_after(err: unknown): number | undefined {
     graph_err.headers as Record<string, string> | undefined,
     graph_err.responseHeaders as Record<string, string> | undefined,
     (graph_err.response as Record<string, unknown> | undefined)?.headers as
-      | Record<string, string>
-      | undefined,
+      Record<string, string> | undefined,
   ];
   for (const headers of headers_sources) {
     if (!headers) continue;

--- a/packages/m365-graph/tests/unit/graph-error-helpers.test.ts
+++ b/packages/m365-graph/tests/unit/graph-error-helpers.test.ts
@@ -280,4 +280,35 @@ describe('with_graph_retry', () => {
     expect(result).toBe('ok');
     expect(calls).toBe(2);
   });
+
+  it('times out a single hung attempt after options.timeout_ms and retries (issue #33)', async () => {
+    let calls = 0;
+    const fn = (): Promise<string> => {
+      calls++;
+      if (calls === 1) {
+        // First attempt hangs past the per-attempt timeout.
+        const { promise } = Promise.withResolvers<string>();
+        return promise;
+      }
+      return Promise.resolve('recovered');
+    };
+
+    const promise = with_graph_retry(fn, { timeout_ms: 5_000 });
+    await vi.advanceTimersByTimeAsync(5_000); // per-attempt timeout fires -> ETIMEDOUT
+    await vi.advanceTimersByTimeAsync(5_000); // backoff before attempt 2
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  it('does not time out an attempt finishing within a widened timeout_ms', async () => {
+    const { promise: slow, resolve } = Promise.withResolvers<string>();
+    setTimeout(() => resolve('large-download'), 120_000); // fake clock
+
+    const promise = with_graph_retry(() => slow, { timeout_ms: 1_800_000 });
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    await expect(promise).resolves.toBe('large-download');
+  });
 });

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -36,6 +36,10 @@ import {
   graph_message_to_mail_message,
 } from '@/adapters/graph-delta-message-mapper';
 
+// 30 min per attempt for attachment $value transfers (up to ~150 MB); the
+// default 60s per-request window kills large bodies on slow links (issue #33).
+const LARGE_DOWNLOAD_TIMEOUT_MS = 1_800_000;
+
 @injectable()
 export class GraphMailboxConnector implements MailboxConnector {
   constructor(@inject(GRAPH_CLIENT_TOKEN) private readonly _client: Client) {}
@@ -47,9 +51,7 @@ export class GraphMailboxConnector implements MailboxConnector {
   async list_mailboxes(_tenant_id: string): Promise<string[]> {
     try {
       const url = '/users?$select=id,mail,displayName&$filter=mail ne null&$top=999';
-      const user_records = await with_graph_retry(() =>
-        this.collect_all_pages<GraphUserRecord>(url),
-      );
+      const user_records = await this.collect_all_pages<GraphUserRecord>(url);
       return extract_user_ids(user_records);
     } catch (err) {
       rethrow_if_access_denied(err);
@@ -95,9 +97,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       const url =
         `/users/${owner_id}/mailFolders` +
         '?$select=id,displayName,parentFolderId,totalItemCount&$top=250';
-      const folder_records = await with_graph_retry(() =>
-        this.collect_all_pages<GraphFolderRecord>(url),
-      );
+      const folder_records = await this.collect_all_pages<GraphFolderRecord>(url);
       return filter_and_map_folders(folder_records);
     } catch (err) {
       rethrow_if_mailbox_not_licensed(err);
@@ -181,9 +181,7 @@ export class GraphMailboxConnector implements MailboxConnector {
   ): Promise<MessageAttachment[]> {
     try {
       const url = `/users/${owner_id}/messages/${message_id}/attachments`;
-      const records = await with_graph_retry(() =>
-        this.collect_all_pages<GraphAttachmentRecord>(url),
-      );
+      const records = await this.collect_all_pages<GraphAttachmentRecord>(url);
       const attachments = map_file_attachments(records);
 
       for (let i = 0; i < attachments.length; i++) {
@@ -208,6 +206,8 @@ export class GraphMailboxConnector implements MailboxConnector {
    * Downloads raw attachment bytes via /attachments/{id}/$value. Raw transfer
    * avoids the +33% base64 overhead of contentBytes. Each attachment gets its
    * own retry window so a large binary cannot starve the page-listing budget.
+   * The widened timeout follows corso's large-file calibration: attachments
+   * run up to 150 MB and the default 60s window kills them on slow links.
    */
   private async download_attachment_content(
     owner_id: string,
@@ -218,6 +218,7 @@ export class GraphMailboxConnector implements MailboxConnector {
     const data = await with_graph_retry(
       () =>
         this._client.api(url).responseType(ResponseType.ARRAYBUFFER).get() as Promise<ArrayBuffer>,
+      { timeout_ms: LARGE_DOWNLOAD_TIMEOUT_MS },
     );
     return Buffer.from(data);
   }
@@ -345,7 +346,14 @@ export class GraphMailboxConnector implements MailboxConnector {
   // Pagination helpers
   // ---------------------------------------------------------------------------
 
-  /** Generic paginator that follows @odata.nextLink and collects all items. */
+  /**
+   * Generic paginator that follows @odata.nextLink and collects all items.
+   * Retry/timeout lives INSIDE the loop (fetch_continuation_page wraps each
+   * page in with_graph_retry), so a failed page resumes from the current
+   * nextLink. NEVER wrap calls to this in with_graph_retry: the outer 60s
+   * timeout races the whole enumeration and restarts it from page 1 --
+   * large tenants can never finish (issue #33).
+   */
   private async collect_all_pages<T>(start_url: string): Promise<T[]> {
     const all_items: T[] = [];
     let current_url: string | undefined = start_url;

--- a/packages/outlook/src/adapters/graph-mailbox-discovery.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-discovery.adapter.ts
@@ -47,7 +47,7 @@ export class GraphMailboxDiscoveryAdapter implements MailboxDiscoveryService {
     options?: MailboxDiscoveryOptions,
   ): Promise<TenantMailbox[]> {
     try {
-      const users = await with_graph_retry(() => this.collectAllUsers());
+      const users = await this.collectAllUsers();
       let mailboxes = map_users_to_tenant_mailboxes(users);
 
       if (options?.licensed_only) {
@@ -80,15 +80,21 @@ export class GraphMailboxDiscoveryAdapter implements MailboxDiscoveryService {
     }
   }
 
+  /**
+   * Pages through /users, retrying each page individually so a failed page
+   * resumes from the current @odata.nextLink. NEVER wrap this whole loop in
+   * with_graph_retry -- the 60s per-request timeout would race the entire
+   * enumeration and restart it from page 1 (issue #33).
+   */
   private async collectAllUsers(): Promise<GraphUserRecord[]> {
     const all: GraphUserRecord[] = [];
     let url: string | undefined = USERS_URL;
 
     while (url) {
-      const page: GraphPageResponse = await this._client
-        .api(url)
-        .header('Prefer', 'odata.maxpagesize=999')
-        .get();
+      const current_url = url;
+      const page: GraphPageResponse = await with_graph_retry(() =>
+        this._client.api(current_url).header('Prefer', 'odata.maxpagesize=999').get(),
+      );
 
       if (page.value) {
         all.push(...page.value);

--- a/packages/outlook/tests/unit/graph-mailbox-connector-listing.test.ts
+++ b/packages/outlook/tests/unit/graph-mailbox-connector-listing.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { GraphMailboxConnector } from '@/adapters/graph-mailbox-connector.adapter';
 import type { MockClient } from './graph-mailbox-connector.harness';
 import { create_mock_client, create_connector } from './graph-mailbox-connector.harness';
@@ -49,6 +49,71 @@ describe('GraphMailboxConnector - listing APIs', () => {
 
       const result = await connector.list_mailboxes('tenant-1');
       expect(result).toEqual(['user-1']);
+    });
+
+    it('resumes a failed page from its nextLink instead of restarting from page 1 (issue #33)', async () => {
+      vi.useFakeTimers();
+      try {
+        mock_client._chain.get
+          .mockResolvedValueOnce({
+            value: [{ id: 'user-1', mail: 'a@test.com' }],
+            '@odata.nextLink': '/users?$skiptoken=page2',
+          })
+          .mockRejectedValueOnce(
+            Object.assign(new Error('service unavailable'), { statusCode: 503 }),
+          )
+          .mockResolvedValueOnce({
+            value: [{ id: 'user-2', mail: 'b@test.com' }],
+          });
+
+        const promise = connector.list_mailboxes('tenant-1');
+        await vi.advanceTimersByTimeAsync(5_000); // skip the retry backoff
+        const result = await promise;
+
+        expect(result).toEqual(['user-1', 'user-2']);
+        const urls = mock_client.api.mock.calls.map((c) => c[0] as string);
+        // Page 1 fetched exactly once: the 503 retried only page 2.
+        expect(urls.filter((u) => !u.includes('skiptoken')).length).toBe(1);
+        expect(urls.filter((u) => u.includes('skiptoken')).length).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('completes an enumeration whose total time exceeds the per-request timeout (issue #33 acceptance)', async () => {
+      vi.useFakeTimers();
+      try {
+        const slow_page =
+          (body: Record<string, unknown>) => (): Promise<Record<string, unknown>> => {
+            const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+            setTimeout(() => resolve(body), 40_000); // each page slower than nothing, total 120s > 60s window
+            return promise;
+          };
+        mock_client._chain.get
+          .mockImplementationOnce(
+            slow_page({
+              value: [{ id: 'u1', mail: 'a@t.com' }],
+              '@odata.nextLink': '/users?$skiptoken=p2',
+            }),
+          )
+          .mockImplementationOnce(
+            slow_page({
+              value: [{ id: 'u2', mail: 'b@t.com' }],
+              '@odata.nextLink': '/users?$skiptoken=p3',
+            }),
+          )
+          .mockImplementationOnce(slow_page({ value: [{ id: 'u3', mail: 'c@t.com' }] }));
+
+        const promise = connector.list_mailboxes('tenant-1');
+        await vi.advanceTimersByTimeAsync(120_000);
+        const result = await promise;
+
+        expect(result).toEqual(['u1', 'u2', 'u3']);
+        // Exactly one fetch per page: no whole-enumeration timeout restarted paging.
+        expect(mock_client.api).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/outlook/tests/unit/mailbox-discovery.test.ts
+++ b/packages/outlook/tests/unit/mailbox-discovery.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { Container } from 'inversify';
 import {
   extract_exchange_license_status,
   map_users_to_tenant_mailboxes,
   parse_mailbox_purpose,
 } from '@/adapters/graph-mailbox-response-mappers';
-import { parse_usage_csv } from '@/adapters/graph-mailbox-discovery.adapter';
+import {
+  GraphMailboxDiscoveryAdapter,
+  parse_usage_csv,
+} from '@/adapters/graph-mailbox-discovery.adapter';
+import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
 import type { GraphAssignedPlan, GraphUserRecord } from '@/adapters/graph-mailbox-response-mappers';
 
 describe('extract_exchange_license_status', () => {
@@ -163,5 +169,51 @@ describe('parse_usage_csv', () => {
     const bob = result.get('bob@contoso.com');
     expect(bob?.storage_bytes).toBe(52428800);
     expect(bob?.item_count).toBe(150);
+  });
+});
+
+describe('GraphMailboxDiscoveryAdapter pagination (issue #33)', () => {
+  it('resumes a failed /users page from its nextLink instead of restarting from page 1', async () => {
+    const get = vi.fn();
+    const chain = { header: vi.fn(), get };
+    chain.header.mockReturnValue(chain);
+    const api = vi.fn().mockReturnValue(chain);
+
+    const licensed_plan = [
+      { service: 'exchange', capabilityStatus: 'Enabled', servicePlanId: 'p' },
+    ];
+    get
+      .mockResolvedValueOnce({
+        value: [{ id: 'u1', mail: 'a@t.com', displayName: 'A', assignedPlans: licensed_plan }],
+        '@odata.nextLink': 'https://graph/users?$skiptoken=page2',
+      })
+      .mockRejectedValueOnce(Object.assign(new Error('throttled'), { statusCode: 429 }))
+      .mockResolvedValueOnce({
+        value: [{ id: 'u2', mail: 'b@t.com', displayName: 'B', assignedPlans: licensed_plan }],
+      })
+      // usage report CSV fetch -- unavailable in this test
+      .mockRejectedValue(new Error('no Reports.Read.All'));
+
+    const container = new Container();
+    container.bind(GRAPH_CLIENT_TOKEN).toConstantValue({ api });
+    container.bind(GraphMailboxDiscoveryAdapter).toSelf();
+    const adapter = container.get(GraphMailboxDiscoveryAdapter);
+
+    vi.useFakeTimers();
+    try {
+      const promise = adapter.list_tenant_mailboxes('t1', { licensed_only: true });
+      await vi.advanceTimersByTimeAsync(5_000); // skip the retry backoff
+      const result = await promise;
+
+      expect(result.map((m) => m.user_id)).toEqual(['u1', 'u2']);
+      const user_urls = api.mock.calls
+        .map((c) => c[0] as string)
+        .filter((u) => u.includes('users'));
+      // Page 1 fetched exactly once: the 429 retried only page 2.
+      expect(user_urls.filter((u) => !u.includes('skiptoken')).length).toBe(1);
+      expect(user_urls.filter((u) => u.includes('skiptoken')).length).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Fixes #33.

The 60s `with_graph_retry` timeout raced entire multi-page enumerations — and since `fetch_continuation_page` already retries per page, the outlook callers had **nested retry**: the outer race fired mid-enumeration regardless of page health and restarted from page 1. Large tenants could never finish; abandoned race arms kept burning Graph quota.

- Outer wraps removed (`list_mailboxes`, `list_mail_folders`, `fetch_attachments`); per-page retry is the single layer, paginators carry NEVER-wrap warnings.
- Discovery `collectAllUsers`: retry moved inside the loop — resumes from `@odata.nextLink`.
- `with_graph_retry` gains `timeout_ms`; `$value` attachment downloads get 30 min (corso large-file calibration).
- Drive connectors audited: already correct.
- AbortSignal socket cancellation deferred (no per-request signal in msgraph-sdk-js) — rationale on issue.

**Proof**: acceptance pinned with fake timers — 120s enumeration completes, exactly one fetch per page; red on old code. Plus discovery resume + timeout_ms tests (both red-on-old). m365-graph 48, outlook 183, onedrive 41, sharepoint 86, cli 41 green; lint clean. Recap on issue.