### PR TITLE
fix(drive): detect and report OneNote notebooks in backups

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -281,6 +281,40 @@ Implementation thresholds from `@wisecom/atlas-onedrive`:
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter) so a transient failure replays a single chunk instead of the whole file.
 
+## OneNote Notebooks
+
+A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
+
+| Item | Facets | Backed up |
+| --- | --- | --- |
+| Notebook root (e.g. `Test`) | `folder` + `package` | Treated as a folder. `GET /items/{id}/content` returns **404** -- the root has no content of its own, so there is nothing to store |
+| `<Section>.one` | `file`, MIME `application/msonenote` | Yes -- byte-for-byte, like any other file |
+| `Open Notebook.onetoc2` | `file` | Yes -- byte-for-byte |
+
+So notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
+
+```
+OneNote notebooks detected: 1 (2 section file(s) backed up as ordinary files).
+```
+
+If any section file of a notebook fails while its siblings succeed, the run warns explicitly:
+
+```
+OneNote notebook "Test" (/Tietoturva/Test) is INCOMPLETE in this backup:
+1 of 2 section file(s) failed (Untitled Section.one).
+A partially captured notebook may not open after restore.
+```
+
+That warning exists because partial capture is the dangerous case: a `.onetoc2` table of contents stored **without** its sibling `.one` sections looks like a successful backup and restores into a notebook that will not open. Notebook completeness is therefore reported per notebook, never averaged into the run's file totals.
+
+### Coverage status and limits
+
+- **Captured:** every `.one` section file and the `.onetoc2` table of contents, at their current revision, in their original folder path.
+- **Reported:** notebook count, section files stored, and an explicit incompleteness warning per notebook.
+- **Restore is byte-faithful, notebook reassembly is not guaranteed.** A restored `.onetoc2` was verified byte-identical to the backed-up copy (SHA-256 match over a live tenant restore). What Atlas cannot promise is that dropping those files back produces a notebook a OneNote client will open: the package facet is created by the OneNote service, not by a file upload, so restored sections arrive as ordinary files. Treat notebook restore as "recover the section data", then let OneNote re-import it, and verify before relying on it.
+- **Version history for section files is often unavailable.** Graph frequently refuses version downloads for `.one` items; those appear in the run as `version download(s) failed`. The current revision is still stored.
+- The notebook root is not stored as a manifest entry (it has no content). Its path is preserved through its children, so restores land the sections back under the same folder structure.
+
 ## Unicode Path Handling
 
 OneDrive paths and file names from Graph are normalized to **Unicode NFC** in the connector and catalog (`String.prototype.normalize('NFC')`). That aligns macOS (often NFD) with Windows/Linux naming so the same logical path does not produce duplicate index entries after sync.

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -285,6 +285,40 @@ Implementation thresholds from `@wisecom/atlas-sharepoint`:
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff) so a transient failure replays a single chunk instead of the whole file.
 
+## OneNote Notebooks
+
+A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
+
+| Item | Facets | Backed up |
+| --- | --- | --- |
+| Notebook root (e.g. `Test`) | `folder` + `package` | Treated as a folder. `GET /items/{id}/content` returns **404** -- the root has no content of its own, so there is nothing to store |
+| `<Section>.one` | `file`, MIME `application/msonenote` | Yes -- byte-for-byte, like any other file |
+| `Open Notebook.onetoc2` | `file` | Yes -- byte-for-byte |
+
+So notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
+
+```
+OneNote notebooks detected: 1 (2 section file(s) backed up as ordinary files).
+```
+
+If any section file of a notebook fails while its siblings succeed, the run warns explicitly:
+
+```
+OneNote notebook "Test" (/Tietoturva/Test) is INCOMPLETE in this backup:
+1 of 2 section file(s) failed (Untitled Section.one).
+A partially captured notebook may not open after restore.
+```
+
+That warning exists because partial capture is the dangerous case: a `.onetoc2` table of contents stored **without** its sibling `.one` sections looks like a successful backup and restores into a notebook that will not open. Notebook completeness is therefore reported per notebook, never averaged into the run's file totals.
+
+### Coverage status and limits
+
+- **Captured:** every `.one` section file and the `.onetoc2` table of contents, at their current revision, in their original folder path.
+- **Reported:** notebook count, section files stored, and an explicit incompleteness warning per notebook.
+- **Restore is byte-faithful, notebook reassembly is not guaranteed.** A restored `.onetoc2` was verified byte-identical to the backed-up copy (SHA-256 match over a live tenant restore). What Atlas cannot promise is that dropping those files back produces a notebook a OneNote client will open: the package facet is created by the OneNote service, not by a file upload, so restored sections arrive as ordinary files. Treat notebook restore as "recover the section data", then let OneNote re-import it, and verify before relying on it.
+- **Version history for section files is often unavailable.** Graph frequently refuses version downloads for `.one` items; those appear in the run as `version download(s) failed`. The current revision is still stored.
+- The notebook root is not stored as a manifest entry (it has no content). Its path is preserved through its children, so restores land the sections back under the same folder structure.
+
 ## Download Resilience
 
 SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.graph.downloadUrl`) are subject to Microsoft Graph rate limiting. Atlas handles this with:

--- a/packages/core/src/services/shared/package-item-reporter.ts
+++ b/packages/core/src/services/shared/package-item-reporter.ts
@@ -1,0 +1,86 @@
+/**
+ * Accounting for Graph `package` items (OneNote notebooks) in drive backups.
+ *
+ * A notebook root carries the `package` facet alongside a `folder` facet, so
+ * backup treats it as a folder and stores its `.one` / `.onetoc2` children as
+ * ordinary files. The content is therefore captured, but without this
+ * accounting nothing in the run says a notebook exists or whether it came
+ * through whole.
+ *
+ * That matters because a notebook is only usable if all of its parts are
+ * present: a `.onetoc2` table of contents stored without its sibling section
+ * files restores as a notebook that will not open. Partial capture is reported
+ * per notebook rather than averaged into the run's file counters.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/package
+ */
+
+/** The delta-item fields this accounting needs, shared by OneDrive and SharePoint. */
+export interface PackageAwareDeltaItem {
+  readonly item_id: string;
+  readonly file_name: string;
+  readonly parent_path: string;
+  readonly kind: 'file' | 'folder';
+  readonly deleted: boolean;
+  /** Graph package facet type (e.g. `oneNote`); absent for ordinary items. */
+  readonly package_type?: string | undefined;
+}
+
+export interface PackageReport {
+  /** Package roots seen in this delta batch. */
+  readonly notebooks_detected: number;
+  /** Files stored from inside those packages. */
+  readonly section_files_backed_up: number;
+  /** One line per notebook that came through incomplete. */
+  readonly warnings: string[];
+}
+
+/**
+ * Summarizes package items in one delta batch.
+ *
+ * @param items - Every item in the batch, roots and children alike.
+ * @param failed_item_ids - Items that failed to back up in this run.
+ */
+export function summarize_package_items(
+  items: readonly PackageAwareDeltaItem[],
+  failed_item_ids: ReadonlySet<string>,
+): PackageReport {
+  const roots = items.filter((i) => i.package_type !== undefined && !i.deleted);
+  if (roots.length === 0) {
+    return { notebooks_detected: 0, section_files_backed_up: 0, warnings: [] };
+  }
+
+  const warnings: string[] = [];
+  let section_files_backed_up = 0;
+
+  for (const root of roots) {
+    const root_path = join_path(root.parent_path, root.file_name);
+    const children = items.filter(
+      (i) => i.kind === 'file' && !i.deleted && is_inside(i.parent_path, root_path),
+    );
+    const failed = children.filter((c) => failed_item_ids.has(c.item_id));
+
+    section_files_backed_up += children.length - failed.length;
+
+    if (failed.length > 0) {
+      warnings.push(
+        `OneNote notebook "${root.file_name}" (${root_path}) is INCOMPLETE in this backup: ` +
+          `${failed.length} of ${children.length} section file(s) failed ` +
+          `(${failed.map((f) => f.file_name).join(', ')}). ` +
+          'A partially captured notebook may not open after restore.',
+      );
+    }
+  }
+
+  return { notebooks_detected: roots.length, section_files_backed_up, warnings };
+}
+
+/** Joins a parent path and name into a normalized `/a/b` path. */
+function join_path(parent_path: string, name: string): string {
+  return parent_path === '/' ? `/${name}` : `${parent_path}/${name}`;
+}
+
+/** True when `path` is the given root or nested beneath it. */
+function is_inside(path: string, root_path: string): boolean {
+  return path === root_path || path.startsWith(`${root_path}/`);
+}

--- a/packages/core/tests/unit/services/shared/package-item-reporter.test.ts
+++ b/packages/core/tests/unit/services/shared/package-item-reporter.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarize_package_items,
+  type PackageAwareDeltaItem,
+} from '@/services/shared/package-item-reporter';
+
+function notebook(name: string, parent_path = '/Docs'): PackageAwareDeltaItem {
+  return {
+    item_id: `nb-${name}`,
+    file_name: name,
+    parent_path,
+    kind: 'folder',
+    deleted: false,
+    package_type: 'oneNote',
+  };
+}
+
+function section(name: string, parent_path: string, item_id = `f-${name}`): PackageAwareDeltaItem {
+  return { item_id, file_name: name, parent_path, kind: 'file', deleted: false };
+}
+
+const NO_FAILURES: ReadonlySet<string> = new Set();
+
+describe('summarize_package_items', () => {
+  it('reports nothing when the batch holds no package items', () => {
+    const report = summarize_package_items(
+      [section('report.pdf', '/Docs'), section('notes.txt', '/Docs')],
+      NO_FAILURES,
+    );
+
+    expect(report).toEqual({ notebooks_detected: 0, section_files_backed_up: 0, warnings: [] });
+  });
+
+  it('counts a notebook and the section files stored beneath it', () => {
+    const report = summarize_package_items(
+      [
+        notebook('Test'),
+        section('Untitled Section.one', '/Docs/Test'),
+        section('Open Notebook.onetoc2', '/Docs/Test'),
+        section('unrelated.pdf', '/Docs'),
+      ],
+      NO_FAILURES,
+    );
+
+    expect(report.notebooks_detected).toBe(1);
+    expect(report.section_files_backed_up).toBe(2);
+    expect(report.warnings).toEqual([]);
+  });
+
+  it('counts section files nested deeper inside the notebook', () => {
+    const report = summarize_package_items(
+      [notebook('Test'), section('Deep.one', '/Docs/Test/Group')],
+      NO_FAILURES,
+    );
+
+    expect(report.section_files_backed_up).toBe(1);
+  });
+
+  it('does not claim a sibling folder with a shared name prefix', () => {
+    const report = summarize_package_items(
+      [notebook('Test'), section('other.one', '/Docs/TestArchive')],
+      NO_FAILURES,
+    );
+
+    expect(report.section_files_backed_up).toBe(0);
+  });
+
+  it('warns that a notebook is incomplete when one section fails', () => {
+    const report = summarize_package_items(
+      [
+        notebook('Test'),
+        section('Untitled Section.one', '/Docs/Test', 'bad'),
+        section('Open Notebook.onetoc2', '/Docs/Test', 'good'),
+      ],
+      new Set(['bad']),
+    );
+
+    expect(report.section_files_backed_up).toBe(1);
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toContain('INCOMPLETE');
+    expect(report.warnings[0]).toContain('Untitled Section.one');
+    expect(report.warnings[0]).toContain('1 of 2');
+  });
+
+  it('keeps notebooks independent so one failure does not taint the others', () => {
+    const report = summarize_package_items(
+      [
+        notebook('Broken'),
+        section('a.one', '/Docs/Broken', 'bad'),
+        notebook('Fine'),
+        section('b.one', '/Docs/Fine', 'ok'),
+      ],
+      new Set(['bad']),
+    );
+
+    expect(report.notebooks_detected).toBe(2);
+    expect(report.section_files_backed_up).toBe(1);
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toContain('Broken');
+  });
+
+  it('handles a notebook sitting at the drive root', () => {
+    const report = summarize_package_items(
+      [notebook('Test', '/'), section('a.one', '/Test')],
+      NO_FAILURES,
+    );
+
+    expect(report.section_files_backed_up).toBe(1);
+  });
+
+  it('ignores a deleted notebook root', () => {
+    const report = summarize_package_items(
+      [{ ...notebook('Test'), deleted: true }, section('a.one', '/Docs/Test')],
+      NO_FAILURES,
+    );
+
+    expect(report.notebooks_detected).toBe(0);
+  });
+});

--- a/packages/onedrive/src/adapters/graph-onedrive-connector.adapter.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-connector.adapter.ts
@@ -66,6 +66,7 @@ const DRIVE_DELTA_SELECT_FIELDS = [
   'parentReference',
   'file',
   'folder',
+  'package',
   '@microsoft.graph.downloadUrl',
 ].join(',');
 
@@ -247,10 +248,10 @@ export class GraphOneDriveConnector implements OneDriveConnector {
     drive_id: string,
     prev_delta_link: string | undefined,
   ): Promise<{ page: GraphCollectionResponse<GraphDeltaDriveItem>; stale_cursor: boolean }> {
-    const stale_cursor = Boolean(prev_delta_link && !prev_delta_link.includes('$select='));
+    const stale_cursor = Boolean(prev_delta_link && !prev_delta_link.includes('package'));
     if (stale_cursor) {
       logger.warn(
-        `Delta cursor for drive ${drive_id} predates field selection — performing fresh delta`,
+        `Delta cursor for drive ${drive_id} predates package-facet selection — performing fresh delta`,
       );
     }
 

--- a/packages/onedrive/src/adapters/graph-onedrive-delta-mapper.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-delta-mapper.ts
@@ -14,6 +14,7 @@ interface GraphDeltaDriveItem {
   parentReference?: GraphParentReference;
   file?: Record<string, unknown>;
   folder?: Record<string, unknown>;
+  package?: { type?: string };
   '@removed'?: { reason: string };
   '@microsoft.graph.downloadUrl'?: string;
 }
@@ -51,6 +52,7 @@ export function map_delta_item(raw: GraphDeltaDriveItem, drive_id: string): OneD
     parent_path,
     size_bytes: raw.size ?? 0,
     deleted: is_deleted,
+    ...(raw.package ? { package_type: raw.package.type ?? 'unknown' } : {}),
     ...(raw.webUrl ? { web_url: raw.webUrl } : {}),
     ...(raw.eTag ? { etag: raw.eTag } : {}),
     ...(raw.lastModifiedDateTime ? { last_modified_at: raw.lastModifiedDateTime } : {}),

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -1,7 +1,6 @@
 import type {
   BackupProgressReporter,
   OneDriveConnector,
-  OneDriveDeltaItem,
   OneDriveDeltaResult,
   OneDriveDrive,
   OneDriveDeltaCursorRepository,
@@ -11,30 +10,26 @@ import type {
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
-  accumulate_version_stats,
-  build_deleted_entry,
-  build_stored_entry,
-} from '@/services/onedrive-backup-builders';
-import { process_backup_file } from '@/services/onedrive-backup-file-processor';
-import { classify_change_type } from '@/services/onedrive-change-classifier';
-import { sync_file_versions } from '@/services/onedrive-version-sync';
+  summarize_package_items,
+  type PackageReport,
+} from '@wisecom/atlas-core/services/shared/package-item-reporter';
+import {
+  clear_file_tracking_on_reset,
+  process_delta_item,
+  type DriveTrackingState,
+  type VersionStats,
+} from '@/services/onedrive-delta-item-processor';
 import {
   make_item_progress_callback,
   report_drive_success,
   type ScanProgressTotals,
 } from '@/services/onedrive-scan-progress';
 
-export interface DriveTrackingState {
-  previous_path_by_file_id: Record<string, string>;
-  previous_name_by_file_id: Record<string, string>;
-  previous_etag_by_file_id: Record<string, string>;
-  previous_kind_by_file_id: Record<string, 'file' | 'folder'>;
-}
-
-export interface VersionStats {
-  total_versions_stored: number;
-  total_versions_unavailable: number;
-  total_versions_failed: number;
+/** Package accounting summed across every drive in one run. */
+export interface PackageReportTotals {
+  notebooks_detected: number;
+  section_files_backed_up: number;
+  warnings: string[];
 }
 
 export interface SingleDriveResult {
@@ -45,101 +40,7 @@ export interface SingleDriveResult {
   success: boolean;
   delta_link?: string;
   errors: string[];
-}
-
-/** Clears file tracking maps when Graph signals a delta reset. */
-export function clear_file_tracking_on_reset(state: DriveTrackingState): void {
-  for (const [fid, kind] of Object.entries(state.previous_kind_by_file_id)) {
-    if (kind === 'file') {
-      delete state.previous_path_by_file_id[fid];
-      delete state.previous_name_by_file_id[fid];
-      delete state.previous_etag_by_file_id[fid];
-    }
-  }
-}
-
-interface DeltaItemOutcome {
-  entry?: OneDriveManifestEntry;
-  files_stored: number;
-  files_deduplicated: number;
-  deleted_items: number;
-  error?: string;
-}
-
-/** Processes one delta item and returns manifest entries or errors. */
-export async function process_delta_item(
-  connector: OneDriveConnector,
-  file_indexes: OneDriveFileVersionIndexRepository,
-  item: OneDriveDeltaItem,
-  owner_id: string,
-  snapshot_id: string,
-  ctx: TenantContext,
-  state: DriveTrackingState,
-  version_stats: VersionStats,
-  on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
-): Promise<DeltaItemOutcome> {
-  const effective_kind =
-    item.deleted && item.kind === 'file' && state.previous_kind_by_file_id[item.item_id]
-      ? state.previous_kind_by_file_id[item.item_id]
-      : item.kind;
-
-  if (effective_kind !== 'file') {
-    if (!item.deleted) state.previous_kind_by_file_id[item.item_id] = item.kind;
-    return { files_stored: 0, files_deduplicated: 0, deleted_items: 0 };
-  }
-
-  const change_type = classify_change_type(
-    item,
-    state.previous_path_by_file_id,
-    state.previous_name_by_file_id,
-    state.previous_etag_by_file_id,
-  );
-  if (!change_type) {
-    return { files_stored: 0, files_deduplicated: 0, deleted_items: 0 };
-  }
-
-  if (item.deleted) {
-    return {
-      entry: build_deleted_entry(item, change_type),
-      files_stored: 0,
-      files_deduplicated: 0,
-      deleted_items: 1,
-    };
-  }
-
-  const result = await process_backup_file(connector, item, owner_id, ctx);
-  if (!result) {
-    return {
-      files_stored: 0,
-      files_deduplicated: 0,
-      deleted_items: 0,
-      error: `Failed to process file ${item.file_name} (${item.item_id})`,
-    };
-  }
-
-  if (!result.deduplicated) {
-    const version_result = await sync_file_versions(
-      connector,
-      item,
-      owner_id,
-      snapshot_id,
-      ctx,
-      file_indexes,
-    );
-    accumulate_version_stats(version_result, version_stats, on_version_stats_update);
-  }
-
-  state.previous_path_by_file_id[item.item_id] = item.parent_path;
-  state.previous_name_by_file_id[item.item_id] = item.file_name;
-  state.previous_kind_by_file_id[item.item_id] = 'file';
-  if (item.etag) state.previous_etag_by_file_id[item.item_id] = item.etag;
-
-  return {
-    entry: build_stored_entry(item, result.storage_key, result.checksum, change_type),
-    files_stored: result.stored ? 1 : 0,
-    files_deduplicated: result.deduplicated ? 1 : 0,
-    deleted_items: 0,
-  };
+  package_report: PackageReport;
 }
 
 export interface DriveScanAccumulators {
@@ -148,6 +49,7 @@ export interface DriveScanAccumulators {
   files_deduplicated: number;
   deleted_items: number;
   errors: string[];
+  package_report: PackageReportTotals;
 }
 
 /** Fetches delta changes across all drives and accumulates manifest entries. */
@@ -174,6 +76,7 @@ export async function scan_all_drives(
     files_deduplicated: 0,
     deleted_items: 0,
     errors: [],
+    package_report: { notebooks_detected: 0, section_files_backed_up: 0, warnings: [] },
   };
 
   const totals: ScanProgressTotals = { processed: 0, total: 0, started_at: Date.now() };
@@ -206,6 +109,10 @@ export async function scan_all_drives(
         on_version_stats_update,
         on_item_processed,
       );
+
+      // Notebook accounting stands apart from the entry discard below: a drive
+      // that failed is exactly the one whose notebooks came through incomplete.
+      accumulate_package_report(accumulators.package_report, drive_result.package_report);
 
       if (drive_result.success) {
         accumulators.entries.push(...drive_result.entries);
@@ -244,6 +151,13 @@ export async function scan_all_drives(
   return accumulators;
 }
 
+/** Folds one drive's package report into the run-wide totals. */
+function accumulate_package_report(totals: PackageReportTotals, report: PackageReport): void {
+  totals.notebooks_detected += report.notebooks_detected;
+  totals.section_files_backed_up += report.section_files_backed_up;
+  totals.warnings.push(...report.warnings);
+}
+
 /** Processes delta changes for a single OneDrive drive. */
 export async function process_single_drive(
   connector: OneDriveConnector,
@@ -268,6 +182,7 @@ export async function process_single_drive(
   let drive_files_deduplicated = 0;
   let drive_deleted_items = 0;
   const item_errors: string[] = [];
+  const failed_item_ids = new Set<string>();
 
   for (const item of delta.items) {
     const outcome = await process_delta_item(
@@ -285,6 +200,7 @@ export async function process_single_drive(
 
     if (outcome.error) {
       item_errors.push(outcome.error);
+      failed_item_ids.add(item.item_id);
       continue;
     }
 
@@ -293,6 +209,8 @@ export async function process_single_drive(
     drive_deleted_items += outcome.deleted_items;
     if (outcome.entry) drive_entries.push(outcome.entry);
   }
+
+  const package_report = summarize_package_items(delta.items, failed_item_ids);
 
   if (item_errors.length > 0) {
     logger.warn(
@@ -305,6 +223,7 @@ export async function process_single_drive(
       deleted_items: 0,
       success: false,
       errors: item_errors,
+      package_report,
     };
   }
 
@@ -316,5 +235,6 @@ export async function process_single_drive(
     success: true,
     delta_link: delta.delta_link,
     errors: [],
+    package_report,
   };
 }

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -26,7 +26,10 @@ import {
   persist_snapshot_backup,
 } from '@/services/onedrive-backup-builders';
 import { ensure_drives_discovered } from '@/services/onedrive-backup-file-processor';
-import { scan_all_drives } from '@/services/onedrive-backup-drive-processor';
+import {
+  scan_all_drives,
+  type PackageReportTotals,
+} from '@/services/onedrive-backup-drive-processor';
 import { cleanup_stale_staging } from '@/services/onedrive-large-file-pipeline';
 
 @injectable()
@@ -136,6 +139,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       if (total_versions_failed > 0) {
         warnings.push(`${total_versions_failed} version download(s) failed unexpectedly`);
       }
+      warnings.push(...build_package_warnings(scan_result.package_report));
       const healthy = scan_result.errors.length === 0;
 
       if (scan_result.entries.length === 0) {
@@ -191,4 +195,14 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       ctx.destroy();
     }
   }
+}
+
+/** Renders OneNote accounting as backup warnings: one summary line, then any incomplete notebooks. */
+function build_package_warnings(report: PackageReportTotals): string[] {
+  if (report.notebooks_detected === 0) return [];
+  return [
+    `OneNote notebooks detected: ${report.notebooks_detected} ` +
+      `(${report.section_files_backed_up} section file(s) backed up as ordinary files).`,
+    ...report.warnings,
+  ];
 }

--- a/packages/onedrive/src/services/onedrive-delta-item-processor.ts
+++ b/packages/onedrive/src/services/onedrive-delta-item-processor.ts
@@ -1,0 +1,123 @@
+import type {
+  OneDriveConnector,
+  OneDriveDeltaItem,
+  OneDriveFileVersionIndexRepository,
+  OneDriveManifestEntry,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  accumulate_version_stats,
+  build_deleted_entry,
+  build_stored_entry,
+} from '@/services/onedrive-backup-builders';
+import { process_backup_file } from '@/services/onedrive-backup-file-processor';
+import { classify_change_type } from '@/services/onedrive-change-classifier';
+import { sync_file_versions } from '@/services/onedrive-version-sync';
+
+export interface DriveTrackingState {
+  previous_path_by_file_id: Record<string, string>;
+  previous_name_by_file_id: Record<string, string>;
+  previous_etag_by_file_id: Record<string, string>;
+  previous_kind_by_file_id: Record<string, 'file' | 'folder'>;
+}
+
+export interface VersionStats {
+  total_versions_stored: number;
+  total_versions_unavailable: number;
+  total_versions_failed: number;
+}
+
+export interface DeltaItemOutcome {
+  entry?: OneDriveManifestEntry;
+  files_stored: number;
+  files_deduplicated: number;
+  deleted_items: number;
+  error?: string;
+}
+
+/** Clears file tracking maps when Graph signals a delta reset. */
+export function clear_file_tracking_on_reset(state: DriveTrackingState): void {
+  for (const [fid, kind] of Object.entries(state.previous_kind_by_file_id)) {
+    if (kind === 'file') {
+      delete state.previous_path_by_file_id[fid];
+      delete state.previous_name_by_file_id[fid];
+      delete state.previous_etag_by_file_id[fid];
+    }
+  }
+}
+
+/** Processes one delta item and returns manifest entries or errors. */
+export async function process_delta_item(
+  connector: OneDriveConnector,
+  file_indexes: OneDriveFileVersionIndexRepository,
+  item: OneDriveDeltaItem,
+  owner_id: string,
+  snapshot_id: string,
+  ctx: TenantContext,
+  state: DriveTrackingState,
+  version_stats: VersionStats,
+  on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
+): Promise<DeltaItemOutcome> {
+  const effective_kind =
+    item.deleted && item.kind === 'file' && state.previous_kind_by_file_id[item.item_id]
+      ? state.previous_kind_by_file_id[item.item_id]
+      : item.kind;
+
+  if (effective_kind !== 'file') {
+    if (!item.deleted) state.previous_kind_by_file_id[item.item_id] = item.kind;
+    return { files_stored: 0, files_deduplicated: 0, deleted_items: 0 };
+  }
+
+  const change_type = classify_change_type(
+    item,
+    state.previous_path_by_file_id,
+    state.previous_name_by_file_id,
+    state.previous_etag_by_file_id,
+  );
+  if (!change_type) {
+    return { files_stored: 0, files_deduplicated: 0, deleted_items: 0 };
+  }
+
+  if (item.deleted) {
+    return {
+      entry: build_deleted_entry(item, change_type),
+      files_stored: 0,
+      files_deduplicated: 0,
+      deleted_items: 1,
+    };
+  }
+
+  const result = await process_backup_file(connector, item, owner_id, ctx);
+  if (!result) {
+    return {
+      files_stored: 0,
+      files_deduplicated: 0,
+      deleted_items: 0,
+      error: `Failed to process file ${item.file_name} (${item.item_id})`,
+    };
+  }
+
+  if (!result.deduplicated) {
+    const version_result = await sync_file_versions(
+      connector,
+      item,
+      owner_id,
+      snapshot_id,
+      ctx,
+      file_indexes,
+    );
+    accumulate_version_stats(version_result, version_stats, on_version_stats_update);
+  }
+
+  state.previous_path_by_file_id[item.item_id] = item.parent_path;
+  state.previous_name_by_file_id[item.item_id] = item.file_name;
+  state.previous_kind_by_file_id[item.item_id] = 'file';
+  if (item.etag) state.previous_etag_by_file_id[item.item_id] = item.etag;
+
+  return {
+    entry: build_stored_entry(item, result.storage_key, result.checksum, change_type),
+    files_stored: result.stored ? 1 : 0,
+    files_deduplicated: result.deduplicated ? 1 : 0,
+    deleted_items: 0,
+  };
+}

--- a/packages/onedrive/tests/unit/services/onedrive-package-accounting.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-package-accounting.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveBackupResult,
+  OneDriveDeltaItem,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveBackupService } from '@/services/onedrive-backup.service';
+
+// Issue #52: a OneNote notebook root arrives as a folder carrying the `package`
+// facet and its sections arrive as ordinary files. Nothing downloads from the
+// root, so the run must at least account for the notebook and say when it came
+// through incomplete.
+
+const NOTEBOOK_ROOT: OneDriveDeltaItem = {
+  item_id: 'nb-root',
+  drive_id: 'd1',
+  kind: 'folder',
+  file_name: 'Team Notebook',
+  parent_path: '/Documents',
+  package_type: 'oneNote',
+  size_bytes: 0,
+  deleted: false,
+};
+
+function make_section(item_id: string, file_name: string): OneDriveDeltaItem {
+  return {
+    item_id,
+    drive_id: 'd1',
+    kind: 'file',
+    file_name,
+    parent_path: '/Documents/Team Notebook',
+    size_bytes: 64,
+    etag: `etag-${item_id}`,
+    deleted: false,
+    download_url: `https://example.invalid/${item_id}`,
+  };
+}
+
+function run_backup(
+  items: OneDriveDeltaItem[],
+  failing_item_ids: readonly string[] = [],
+): Promise<OneDriveBackupResult> {
+  const context = {
+    tenant_id: 't',
+    storage: {
+      list: vi.fn().mockResolvedValue([]),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+    },
+    encrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+  const connector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: 'd1', drive_name: 'OneDrive' }]),
+    fetch_delta: vi
+      .fn()
+      .mockResolvedValue({ drive_id: 'd1', delta_link: 'link-1', items, reset_detected: false }),
+    download_file_content: vi.fn(async (item: OneDriveDeltaItem) => {
+      if (failing_item_ids.includes(item.item_id)) throw new Error('403 forbidden');
+      return Buffer.from(item.item_id);
+    }),
+    list_file_versions: vi.fn().mockResolvedValue([]),
+  };
+  const manifests = { save: vi.fn().mockResolvedValue(undefined) };
+  const file_indexes = {
+    find_by_file_id: vi.fn().mockResolvedValue(undefined),
+    append_version: vi.fn().mockResolvedValue(undefined),
+  };
+  const cursors = {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const service = new OneDriveBackupService(
+    factory,
+    connector as never,
+    manifests as never,
+    file_indexes as never,
+    cursors as never,
+  );
+  return service.backup_onedrive('t', 'owner-1', {});
+}
+
+describe('OneNote package accounting (issue #52)', () => {
+  it('reports a detected notebook and its section files', async () => {
+    const result = await run_backup([
+      NOTEBOOK_ROOT,
+      make_section('sec-1', 'Section A.one'),
+      make_section('sec-2', 'Section B.one'),
+    ]);
+
+    expect(result.summary.warnings).toContain(
+      'OneNote notebooks detected: 1 (2 section file(s) backed up as ordinary files).',
+    );
+  });
+
+  it('flags the notebook as INCOMPLETE when a section file fails to download', async () => {
+    const result = await run_backup(
+      [
+        NOTEBOOK_ROOT,
+        make_section('sec-1', 'Section A.one'),
+        make_section('sec-2', 'Section B.one'),
+      ],
+      ['sec-2'],
+    );
+
+    const incomplete = result.summary.warnings.filter((w) => w.includes('INCOMPLETE'));
+    expect(incomplete).toHaveLength(1);
+    expect(incomplete[0]).toContain('Team Notebook');
+    expect(incomplete[0]).toContain('Section B.one');
+    expect(result.summary.warnings).toContain(
+      'OneNote notebooks detected: 1 (1 section file(s) backed up as ordinary files).',
+    );
+  });
+
+  it('stays silent when the delta batch holds no package items', async () => {
+    const result = await run_backup([
+      { ...make_section('f-1', 'Report.docx'), parent_path: '/Documents' },
+    ]);
+
+    expect(result.summary.warnings.filter((w) => w.includes('OneNote'))).toEqual([]);
+  });
+});

--- a/packages/sharepoint/src/adapters/graph-sharepoint-delta-fetch.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-delta-fetch.ts
@@ -19,6 +19,7 @@ const DRIVE_DELTA_SELECT_FIELDS = [
   'parentReference',
   'file',
   'folder',
+  'package',
   '@microsoft.graph.downloadUrl',
 ].join(',');
 
@@ -33,10 +34,10 @@ export async function fetch_initial_delta_page(
   drive_id: string,
   prev_delta_link: string | undefined,
 ): Promise<InitialDeltaPageResult> {
-  const stale_cursor = prev_delta_link && !prev_delta_link.includes('$select=');
+  const stale_cursor = prev_delta_link && !prev_delta_link.includes('package');
   if (stale_cursor) {
     logger.warn(
-      `Delta cursor for drive ${drive_id} predates field selection — performing fresh delta`,
+      `Delta cursor for drive ${drive_id} predates package-facet selection — performing fresh delta`,
     );
   }
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-delta-mapper.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-delta-mapper.ts
@@ -10,6 +10,7 @@ export interface GraphDeltaDriveItem {
   parentReference?: { path?: string };
   file?: Record<string, unknown>;
   folder?: Record<string, unknown>;
+  package?: { type?: string };
   '@removed'?: { reason: string };
   '@microsoft.graph.downloadUrl'?: string;
 }
@@ -34,6 +35,7 @@ export function map_delta_item(raw: GraphDeltaDriveItem, drive_id: string): Shar
     parent_path,
     size_bytes: raw.size ?? 0,
     deleted: is_deleted,
+    ...(raw.package ? { package_type: raw.package.type ?? 'unknown' } : {}),
     ...(raw.webUrl ? { web_url: raw.webUrl } : {}),
     ...(raw.eTag ? { etag: raw.eTag } : {}),
     ...(raw.lastModifiedDateTime ? { last_modified_at: raw.lastModifiedDateTime } : {}),

--- a/packages/sharepoint/src/services/sharepoint-backup-builders.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-builders.ts
@@ -5,7 +5,25 @@ import type {
   SharePointManifestEntry,
   SharePointSnapshotManifest,
 } from '@wisecom/atlas-types';
+import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-item-reporter';
 import type { VersionSyncResult } from '@/services/sharepoint-version-sync';
+
+/**
+ * Flattens per-library package reports into backup summary warnings.
+ *
+ * Emits one informational line for the run plus every per-notebook
+ * incompleteness warning, so a notebook that lost section files is visible
+ * even though its files are stored as ordinary items.
+ */
+export function build_package_warnings(reports: readonly PackageReport[]): string[] {
+  const detected = reports.reduce((n, r) => n + r.notebooks_detected, 0);
+  if (detected === 0) return [];
+  const sections = reports.reduce((n, r) => n + r.section_files_backed_up, 0);
+  return [
+    `OneNote notebooks detected: ${detected} (${sections} section file(s) backed up as ordinary files).`,
+    ...reports.flatMap((r) => r.warnings),
+  ];
+}
 
 export function build_deleted_entry(
   item: SharePointDeltaItem,

--- a/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
@@ -12,6 +12,10 @@ import type {
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
+  summarize_package_items,
+  type PackageReport,
+} from '@wisecom/atlas-core/services/shared/package-item-reporter';
+import {
   accumulate_version_stats,
   build_deleted_entry,
   build_stored_entry,
@@ -34,6 +38,7 @@ export interface LibraryProcessingResult {
   deleted_items: number;
   delta_link?: string;
   had_errors: boolean;
+  package_report: PackageReport;
 }
 
 export interface VersionStatsState {
@@ -67,6 +72,7 @@ export async function process_delta_item(
     library_files_stored: number;
     library_files_deduplicated: number;
     library_deleted_items: number;
+    failed_item_ids: Set<string>;
   },
   file_indexes: SharePointFileVersionIndexRepository,
   version_stats: VersionStatsState,
@@ -98,6 +104,7 @@ export async function process_delta_item(
   const result = await process_backup_file(connector, item, site_id, ctx);
   if (!result) {
     library_state.library_has_errors = true;
+    library_state.failed_item_ids.add(item.item_id);
     errors.push(`Failed to process file ${item.file_name} (${item.item_id})`);
     return;
   }
@@ -168,6 +175,7 @@ export async function process_single_library(
     library_files_stored: 0,
     library_files_deduplicated: 0,
     library_deleted_items: 0,
+    failed_item_ids: new Set<string>(),
   };
 
   for (const item of delta.items) {
@@ -185,6 +193,8 @@ export async function process_single_library(
     );
   }
 
+  const package_report = summarize_package_items(delta.items, library_state.failed_item_ids);
+
   if (library_state.library_has_errors) {
     logger.warn(
       `Library ${library.drive_id}: discarding ${library_state.library_entries.length} entries due to errors`,
@@ -195,6 +205,7 @@ export async function process_single_library(
       files_deduplicated: 0,
       deleted_items: 0,
       had_errors: true,
+      package_report,
     };
   }
 
@@ -213,5 +224,6 @@ export async function process_single_library(
     deleted_items: library_state.library_deleted_items,
     delta_link: delta.delta_link,
     had_errors: false,
+    package_report,
   };
 }

--- a/packages/sharepoint/src/services/sharepoint-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup.service.ts
@@ -20,7 +20,12 @@ import {
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
-import { build_empty_result, build_snapshot_manifest } from '@/services/sharepoint-backup-builders';
+import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-item-reporter';
+import {
+  build_empty_result,
+  build_package_warnings,
+  build_snapshot_manifest,
+} from '@/services/sharepoint-backup-builders';
 import { ensure_libraries_discovered } from '@/services/sharepoint-backup-file-processor';
 import {
   process_single_library,
@@ -85,7 +90,10 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       );
 
       const cursor = this.build_cursor(site_id, delta_link_by_drive, tracking);
-      const warnings = this.build_version_warnings(scan.version_stats);
+      const warnings = [
+        ...this.build_version_warnings(scan.version_stats),
+        ...build_package_warnings(scan.package_reports),
+      ];
       const healthy = scan.errors.length === 0;
 
       if (scan.entries.length === 0) {
@@ -150,6 +158,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     deleted_items: number;
     errors: string[];
     version_stats: VersionStatsState;
+    package_reports: PackageReport[];
   }> {
     const entries: SharePointManifestEntry[] = [];
     let files_stored = 0;
@@ -161,6 +170,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       total_versions_failed: 0,
     };
     const errors: string[] = [];
+    const package_reports: PackageReport[] = [];
 
     for (const library of libraries) {
       try {
@@ -181,6 +191,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
           errors,
         );
 
+        package_reports.push(library_result.package_report);
         if (library_result.had_errors) continue;
 
         entries.push(...library_result.entries);
@@ -194,7 +205,15 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       }
     }
 
-    return { entries, files_stored, files_deduplicated, deleted_items, errors, version_stats };
+    return {
+      entries,
+      files_stored,
+      files_deduplicated,
+      deleted_items,
+      errors,
+      version_stats,
+      package_reports,
+    };
   }
 
   private build_cursor(

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-package-report.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-package-report.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SharePointDeltaItem, SharePointSiteConnector } from '@wisecom/atlas-types';
+import {
+  make_connector,
+  make_cursors,
+  make_file_indexes,
+  make_file_item,
+  make_manifests,
+  make_service,
+} from './sharepoint-backup-determinism.fixtures';
+
+const NOTEBOOK_PATH = '/Docs/Team Notebook';
+
+function make_notebook_root(): SharePointDeltaItem {
+  return make_file_item('nb-1', {
+    kind: 'folder',
+    file_name: 'Team Notebook',
+    parent_path: '/Docs',
+    package_type: 'oneNote',
+    size_bytes: 0,
+  });
+}
+
+function make_section(id: string, name: string): SharePointDeltaItem {
+  return make_file_item(id, { file_name: name, parent_path: NOTEBOOK_PATH });
+}
+
+function connector_with(
+  items: SharePointDeltaItem[],
+  failing_item_id?: string,
+): SharePointSiteConnector {
+  return make_connector({
+    fetch_delta: vi.fn().mockResolvedValue({
+      drive_id: 'drive-1',
+      delta_link: 'https://delta-link',
+      items,
+      reset_detected: false,
+    }),
+    download_file_content: vi.fn((item: SharePointDeltaItem) =>
+      Promise.resolve(item.item_id === failing_item_id ? undefined : Buffer.from(item.item_id)),
+    ),
+  });
+}
+
+async function run_backup(items: SharePointDeltaItem[], failing_item_id?: string) {
+  const service = make_service({
+    connector: connector_with(items, failing_item_id),
+    manifests: make_manifests(),
+    file_indexes: make_file_indexes(),
+    cursors: make_cursors(),
+  });
+  return service.backup_site('tenant-1', 'site-1');
+}
+
+describe('SharePoint backup — OneNote package accounting', () => {
+  it('reports a detected notebook and its section files in the run warnings', async () => {
+    const result = await run_backup([
+      make_notebook_root(),
+      make_section('sec-a', 'Section A.one'),
+      make_section('sec-b', 'Section B.one'),
+    ]);
+
+    expect(result.summary.warnings).toContain(
+      'OneNote notebooks detected: 1 (2 section file(s) backed up as ordinary files).',
+    );
+    expect(result.summary.healthy).toBe(true);
+  });
+
+  it('warns that a notebook is INCOMPLETE when one section file fails to download', async () => {
+    const result = await run_backup(
+      [
+        make_notebook_root(),
+        make_section('sec-a', 'Section A.one'),
+        make_section('sec-b', 'Section B.one'),
+      ],
+      'sec-b',
+    );
+
+    const incomplete = result.summary.warnings.filter((w) => w.includes('INCOMPLETE'));
+    expect(incomplete).toHaveLength(1);
+    expect(incomplete[0]).toContain('Team Notebook');
+    expect(incomplete[0]).toContain(NOTEBOOK_PATH);
+    expect(incomplete[0]).toContain('Section B.one');
+    expect(incomplete[0]).toContain('1 of 2 section file(s) failed');
+    expect(result.summary.healthy).toBe(false);
+  });
+
+  it('adds no notebook lines when the delta batch holds no package items', async () => {
+    const result = await run_backup([make_file_item('plain-1'), make_file_item('plain-2')]);
+
+    expect(result.summary.warnings.filter((w) => w.includes('OneNote'))).toEqual([]);
+    expect(result.summary.healthy).toBe(true);
+  });
+});

--- a/packages/types/src/ports/onedrive/connector.port.ts
+++ b/packages/types/src/ports/onedrive/connector.port.ts
@@ -12,6 +12,8 @@ export interface OneDriveDeltaItem {
   readonly file_name: string;
   readonly parent_path: string;
   readonly web_url?: string;
+  /** Graph package facet type (e.g. `oneNote`) when this item is a package root. */
+  readonly package_type?: string | undefined;
   readonly size_bytes: number;
   readonly etag?: string;
   readonly last_modified_at?: string;

--- a/packages/types/src/ports/sharepoint/connector.port.ts
+++ b/packages/types/src/ports/sharepoint/connector.port.ts
@@ -18,6 +18,8 @@ export interface SharePointDeltaItem {
   readonly file_name: string;
   readonly parent_path: string;
   readonly web_url?: string;
+  /** Graph package facet type (e.g. `oneNote`) when this item is a package root. */
+  readonly package_type?: string | undefined;
   readonly size_bytes: number;
   readonly etag?: string;
   readonly last_modified_at?: string;


### PR DESCRIPTION
Closes #52

## Spike first — the issue's premise turned out to be wrong

The issue predicted notebooks were **absent from backups** ("neither a `file` nor a `folder` facet" → dropped). A live spike against a real OneNote notebook created in the tenant says otherwise, and the fix follows the evidence rather than the prediction. What Graph actually returns:

| Item | Facets | Reality today |
| --- | --- | --- |
| Notebook root `Test` | `folder: {childCount: 2}` **+** `package: {type: oneNote}` | Classified as a folder — a defensible bucket, not a drop. `GET /items/{id}/content` → **404**: no content to store |
| `Untitled Section.one` | `file`, `application/msonenote` | Ordinary file item — **already backed up** |
| `Open Notebook.onetoc2` | `file` | Ordinary file item — **already backed up** |

Both children download intact (16 505 B and 6 602 B, matching OneNote magic `e4525c7b8cd8a74d`), and an end-to-end backup + `save` produced them on disk:

```
Tietoturva/Test/Untitled Section.one
Tietoturva/Test/Open Notebook.onetoc2
Tietoturva/Test/Demo.one
Tietoturva/Test/Demo 2.one
Tietoturva/Test/Default.one
```

So notebook **content was never missing**. This matches the reference note in the issue thread (corso treats sections as ordinary files) and confirms the commenter's suspicion that "the acute bug may be narrower".

**The real defect is accounting.** Nothing in a run said a notebook existed or whether it came through whole — and completeness is what decides whether a notebook survives: a `.onetoc2` stored without its sibling `.one` sections looks like a clean backup and restores into a notebook that will not open. That is precisely the corso FIXME the thread warned about.

## Fix

- `package` added to both delta `$select` lists; both mappers map it to `package_type` on the delta item.
- Shared accounting in `packages/core/src/services/shared/package-item-reporter.ts` so OneDrive and SharePoint report identically: notebooks are matched to their children by path containment, and completeness is tracked **per notebook** instead of being averaged into the run's file counters.
- Each run reports `OneNote notebooks detected: {N} ({M} section file(s) backed up as ordinary files).`
- A notebook with some failed sections raises an explicit warning naming the notebook and the failed files, stating the restore risk. SharePoint reports this even when the library's entries are discarded, so an incomplete notebook cannot hide behind a failed library.
- Delta links that predate the package selection force a fresh delta, so existing cursors start reporting notebooks immediately instead of waiting for a reset.

No new ports, tokens, or manifest schema changes: the root has no content, so it needs no manifest entry, and its path already survives through its children.

## Verification

**Live**, against the notebook in `WisecomIntranet`:

```
Libraries scanned: 1
[+] Snapshot sp-snap-1786433804752-2f70f5 created
24 changed | 0 stored | 24 dedup
[!] OneNote notebooks detected: 1 (5 section file(s) backed up as ordinary files).
[+] Status: HEALTHY
```

**Unit:** 14 new tests — 8 for the shared reporter (path containment, sibling-prefix rejection, root-level notebooks, per-notebook isolation, deleted roots, partial-failure warning), 3 for SharePoint, 3 for OneDrive. Workspace suite 718 green; lint and `docs:build` clean.

## Acceptance criteria

- [x] Package items are detected and reported, never silently dropped
- [x] Spike outcome recorded — see above and both backup guides
- [x] Docs state OneNote coverage status

## Restore fidelity — answered, with a caveat, and it uncovered a separate bug

The spike also asked whether restored files re-open as a working notebook. Restoring the snapshot exposed **#71: `atlas sharepoint restore --target-site` is ignored and writes into the source site** — the upload uses each manifest entry's stored `drive_id`, so the declared target received nothing (`Documents` root children: `[]`) while the source library gained renamed duplicates. Filed separately with evidence; the duplicates were deleted and the tenant is back to its original state.

What could still be established: a restored `.onetoc2` is **byte-identical** to the backed-up copy (SHA-256 match). What cannot be established until #71 is fixed: whether a restored set re-opens as a notebook, since the package facet is created by the OneNote service and not by a file upload. Both backup guides now state exactly this rather than implying notebook-level restore.

## Docs

New "OneNote Notebooks" section in `docs/sharepoint-backup.md` and `docs/onedrive-backup.md`: facet table, the reported lines, the incompleteness warning and why it exists, and an explicit coverage-and-limits list (including that Graph frequently refuses version-history downloads for `.one` items — observed in the same runs).
