### PR TITLE
ci: run the pipeline for release branches too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    # Release branches are integration targets for a whole beta line, so they
+    # need the same gate as main -- without this, PRs into release/** merge
+    # with no build, lint, format, or test run at all.
+    branches: [main, 'release/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Merge this first — it unblocks CI for every other open PR

`.github/workflows/ci.yml` triggers only on `main`:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

`release/v2.1.0-beta` is the integration branch for the whole beta line, so **every PR merged into it so far ran no CI at all** — no build, no lint, no format check, no tests. #64, #65, #66 and #67 all merged unchecked, and the four open PRs (#69, #70, #72, #73) show no checks for the same reason.

The only CI run that exists on #69 happened because that PR was briefly opened against `main` before being retargeted.

## Why this must merge before the others

For `pull_request` events GitHub decides whether a workflow applies using the trigger filters **on the base branch**. Adding `release/**` inside a feature branch therefore does nothing for that branch's own PR — verified: pushing this change onto `fix/47-nested-mail-folders` produced no run. It only takes effect once it is on `release/v2.1.0-beta` itself, after which the open PRs get a real run on their next push.

## Change

```yaml
on:
  push:
    branches: [main, 'release/**']
  pull_request:
    branches: [main, 'release/**']
```

Nothing else — same job, same steps.

## Heads-up: the pipeline is currently red for a pre-existing reason

`Format check` fails on the base branch on two files that predate all of this work and were formatted by an older prettier (the lockfile now resolves 3.9.5):

- `packages/m365-graph/src/graph-error-helpers.ts`
- `packages/sharepoint/tests/unit/services/sharepoint-backup-determinism.fixtures.ts`

Because `Format check` runs before `Test with coverage`, the test step is skipped entirely — so once CI starts running here it will go red until those two files are reformatted. The fix (`prettier --write` on both, formatting only) is already carried in #69, so merging #69 clears it; otherwise it is a 30-second follow-up.

Locally, on both #69 and #70 branches, the full CI step sequence — `pnpm run build`, `pnpm run lint`, `pnpm run format:check`, `pnpm run test` — passes.
