### PR TITLE
fix(sharepoint): restore --target-site into the target site, not the source

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -491,9 +491,10 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 | `-t, --tenant <id>` | Override tenant ID from config |
 
 With `--target-site`, each file goes to the target library whose name matches the
-one it was backed up from, or to the target's only library when it has just one.
-If several libraries exist and none matches, the file is refused and the command
-exits non-zero -- Atlas never writes into the source library instead. See
+one it was backed up from, or -- when the restore comes from a single library --
+to the target's only library. Anything ambiguous is refused: the file is skipped,
+the candidate libraries are listed, and the command exits non-zero. Atlas never
+writes into the source library instead. See
 [Where a cross-site restore lands](../sharepoint-backup.md#where-a-cross-site-restore-lands).
 
 **`atlas sharepoint save`**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -490,6 +490,12 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 | `-c, --conflict <mode>` | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
 | `-t, --tenant <id>` | Override tenant ID from config |
 
+With `--target-site`, each file goes to the target library whose name matches the
+one it was backed up from, or to the target's only library when it has just one.
+If several libraries exist and none matches, the file is refused and the command
+exits non-zero -- Atlas never writes into the source library instead. See
+[Where a cross-site restore lands](../sharepoint-backup.md#where-a-cross-site-restore-lands).
+
 **`atlas sharepoint save`**
 
 Save decrypted files from a SharePoint snapshot to a local zip archive. The archive preserves the original folder structure from document libraries. Each file is SHA-256 verified after decryption by default.

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -238,25 +238,29 @@ therefore has to pick a library belonging to the target site, which Atlas does
 per entry:
 
 1. **Same library name.** The target library whose name matches the one the file
-   was backed up from (case-insensitive). This keeps a multi-library site's
-   structure intact when the names line up on both ends.
-2. **The only library.** If the target site has exactly one document library, it
-   receives everything. Library names are localised -- a Finnish tenant's default
-   library is `Tiedostot`, an English one's is `Documents` -- so a single-library
-   target must not be decided by name.
-3. **Neither.** If several libraries exist and none matches, Atlas refuses the
-   file, names the candidates, and the run exits non-zero. It never guesses which
-   production library should receive the data, and never falls back to the
-   library the file came from.
+   was backed up from -- compared case-insensitively, in Unicode NFC, ignoring
+   surrounding whitespace. This keeps a multi-library site's structure intact when
+   the names line up on both ends. If *two* target libraries share that name the
+   choice is ambiguous, so Atlas refuses rather than pick one.
+2. **The only library**, and only when the restore comes from a single source
+   library. Library names are localised -- a Finnish tenant's default library is
+   `Tiedostot`, an English one's is `Documents` -- so a single-library target must
+   not be decided by name. This rule deliberately does *not* apply when the
+   snapshot spans several libraries: folding them into one destination merges
+   their trees, and two files sharing a path would overwrite each other under
+   `--conflict replace`. Restore those one library at a time with `--file-filter`.
+3. **Neither.** Atlas refuses the file, names the candidate libraries, and the run
+   exits non-zero. It never guesses which production library should receive the
+   data, and never falls back to the library the file came from.
 
 If the target site has no document libraries at all, the restore fails before
 uploading anything.
 
 ::: warning Snapshots taken before 2.1.0-beta
 Library names were not recorded in older manifests, so rule 1 cannot apply to
-them. Restoring such a snapshot into a target site with several libraries fails
-by rule 3 rather than choosing one. Take a fresh backup, or restore into a
-single-library site.
+them. Such a snapshot restores cross-site only when it came from one library and
+the target has one library; anything else fails by rule 3 rather than choosing a
+destination. Take a fresh backup to restore by name.
 :::
 
 ### `atlas sharepoint save`

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -229,6 +229,36 @@ console.log(site.id);
 | `-c, --conflict <mode>` | File conflict policy: `replace`, `rename`, or `fail` | `rename` |
 | `-t, --tenant <id>` | Tenant identifier | Config default |
 
+#### Where a cross-site restore lands
+
+A manifest entry records the `drive_id` of the library it came from, and that id
+is only meaningful inside the site that owns it -- Graph addresses an upload as
+`/sites/{site}/drives/{drive}/...`, and the drive wins. `--target-site`
+therefore has to pick a library belonging to the target site, which Atlas does
+per entry:
+
+1. **Same library name.** The target library whose name matches the one the file
+   was backed up from (case-insensitive). This keeps a multi-library site's
+   structure intact when the names line up on both ends.
+2. **The only library.** If the target site has exactly one document library, it
+   receives everything. Library names are localised -- a Finnish tenant's default
+   library is `Tiedostot`, an English one's is `Documents` -- so a single-library
+   target must not be decided by name.
+3. **Neither.** If several libraries exist and none matches, Atlas refuses the
+   file, names the candidates, and the run exits non-zero. It never guesses which
+   production library should receive the data, and never falls back to the
+   library the file came from.
+
+If the target site has no document libraries at all, the restore fails before
+uploading anything.
+
+::: warning Snapshots taken before 2.1.0-beta
+Library names were not recorded in older manifests, so rule 1 cannot apply to
+them. Restoring such a snapshot into a target site with several libraries fails
+by rule 3 rather than choosing one. Take a fresh backup, or restore into a
+single-library site.
+:::
+
 ### `atlas sharepoint save`
 
 | Flag | Description | Default |
@@ -366,7 +396,7 @@ SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.g
 
 ## Restore
 
-Restore decrypts stored file blobs, verifies SHA-256 checksums, and uploads them back to the site's document libraries via Graph API. Each manifest entry carries its own `drive_id`, so files are restored to the correct document library automatically.
+Restore decrypts stored file blobs, verifies SHA-256 checksums, and uploads them back to a site's document libraries via Graph API. Restoring in place uses each manifest entry's own `drive_id`, so files return to the library they came from. Restoring to another site with `--target-site` re-points every upload at a library of that site -- see [Where a cross-site restore lands](#where-a-cross-site-restore-lands).
 
 **CLI:**
 

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -1,3 +1,4 @@
+import { Option } from 'commander';
 import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import {
@@ -55,9 +56,12 @@ function register_onedrive_restore(group: Command, get_container: ContainerFacto
     .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
     .option('--target-owner <id>', 'target user email or Entra object ID (defaults to owner)')
     .option('--file-filter <paths...>', 'only restore specific files (by ID or path)')
-    .option(
-      '-c, --conflict <mode>',
-      'file conflict policy: replace, rename, or fail (default: rename)',
+    .addOption(
+      new Option('-c, --conflict <mode>', 'file conflict policy (default: rename)').choices([
+        'replace',
+        'rename',
+        'fail',
+      ]),
     )
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .action((options: OneDriveRestoreCommandOptions) =>

--- a/packages/cli/src/commands/sharepoint.command.ts
+++ b/packages/cli/src/commands/sharepoint.command.ts
@@ -1,3 +1,4 @@
+import { Option } from 'commander';
 import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import {
@@ -75,9 +76,12 @@ function register_sharepoint_restore(group: Command, get_container: ContainerFac
     .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
     .option('--target-site <url-or-id>', 'target site to restore to (defaults to original site)')
     .option('--file-filter <paths...>', 'only restore specific files (by ID or path)')
-    .option(
-      '-c, --conflict <mode>',
-      'file conflict policy: replace, rename, or fail (default: rename)',
+    .addOption(
+      new Option('-c, --conflict <mode>', 'file conflict policy (default: rename)').choices([
+        'replace',
+        'rename',
+        'fail',
+      ]),
     )
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .action((options: SharePointRestoreCommandOptions) =>

--- a/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
@@ -135,7 +135,8 @@ export async function graph_onedrive_upload_small_file(
 ): Promise<void> {
   const parent_ref = parent_id === 'root' ? 'root' : `items/${parent_id}`;
   const encoded_name = encodeURIComponent(file_name);
-  const conflict_qs = `@microsoft.graph.conflictBehavior=${conflict_behavior}`;
+  // Encoded: an unescaped value could append a second conflictBehavior to the query.
+  const conflict_qs = `@microsoft.graph.conflictBehavior=${encodeURIComponent(conflict_behavior)}`;
   await with_graph_retry(
     () =>
       client

--- a/packages/sharepoint/src/adapters/graph-sharepoint-connector.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-connector.adapter.ts
@@ -120,25 +120,37 @@ export class GraphSharePointConnector implements SharePointSiteConnector {
     );
   }
 
-  /** Lists document libraries (drives) within a site. */
+  /**
+   * Lists document libraries (drives) within a site, following continuation
+   * links: restore routing treats this list as the complete set of destinations,
+   * so a truncated page would send files to the wrong library.
+   */
   async list_document_libraries(
     _tenant_id: string,
     site_id: string,
   ): Promise<SharePointDocumentLibrary[]> {
+    const libraries: SharePointDocumentLibrary[] = [];
+    let next_url: string | undefined = `/sites/${site_id}/drives?$select=id,name`;
+
     try {
-      const response = await with_graph_retry(
-        () =>
-          this._client.api(`/sites/${site_id}/drives?$select=id,name`).get() as Promise<
-            GraphCollectionResponse<GraphDriveRecord>
-          >,
-      );
-      return (response.value ?? [])
-        .filter((drive) => Boolean(drive.id))
-        .map((drive) => ({ drive_id: drive.id ?? '', drive_name: drive.name ?? '' }));
+      while (next_url) {
+        const url = next_url;
+        // Retry wraps a single page, never the whole walk.
+        const page: GraphCollectionResponse<GraphDriveRecord> = await with_graph_retry(
+          () => this._client.api(url).get() as Promise<GraphCollectionResponse<GraphDriveRecord>>,
+        );
+        for (const drive of page.value ?? []) {
+          if (!drive.id) continue;
+          libraries.push({ drive_id: drive.id, drive_name: drive.name ?? '' });
+        }
+        next_url = page['@odata.nextLink'];
+      }
     } catch (err) {
       rethrow_if_access_denied(err);
       throw err;
     }
+
+    return libraries;
   }
 
   /** Fetches delta changes since the last sync, with automatic reset handling. */

--- a/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
@@ -133,7 +133,8 @@ export async function graph_sharepoint_upload_small_file(
 ): Promise<void> {
   const parent_ref = parent_id === 'root' ? 'root' : `items/${parent_id}`;
   const encoded_name = encodeURIComponent(file_name);
-  const conflict_qs = `@microsoft.graph.conflictBehavior=${conflict_behavior}`;
+  // Encoded: an unescaped value could append a second conflictBehavior to the query.
+  const conflict_qs = `@microsoft.graph.conflictBehavior=${encodeURIComponent(conflict_behavior)}`;
   await with_graph_retry(
     () =>
       client

--- a/packages/sharepoint/src/services/sharepoint-backup-builders.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-builders.ts
@@ -28,10 +28,12 @@ export function build_package_warnings(reports: readonly PackageReport[]): strin
 export function build_deleted_entry(
   item: SharePointDeltaItem,
   change_type: SharePointChangeType,
+  library_name: string,
 ): SharePointManifestEntry {
   return {
     file_id: item.item_id,
     drive_id: item.drive_id,
+    library_name,
     file_name: item.file_name,
     parent_path: item.parent_path,
     size_bytes: item.size_bytes,
@@ -48,10 +50,12 @@ export function build_stored_entry(
   storage_key: string,
   checksum: string,
   change_type: SharePointChangeType,
+  library_name: string,
 ): SharePointManifestEntry {
   return {
     file_id: item.item_id,
     drive_id: item.drive_id,
+    library_name,
     file_name: item.file_name,
     parent_path: item.parent_path,
     size_bytes: item.size_bytes,

--- a/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
@@ -84,6 +84,7 @@ export async function process_single_library(
 
   const library_state: LibraryProcessingState = {
     library_entries: [],
+    library_name: library.drive_name,
     library_files_stored: 0,
     library_files_deduplicated: 0,
     library_deleted_items: 0,

--- a/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
@@ -30,6 +30,8 @@ export interface FileTrackingState {
 
 export interface LibraryProcessingState {
   library_entries: SharePointManifestEntry[];
+  /** Name of the library being processed, recorded so a cross-site restore can place these entries. */
+  library_name: string;
   library_files_stored: number;
   library_files_deduplicated: number;
   library_deleted_items: number;
@@ -79,7 +81,9 @@ export async function process_delta_item(
 
   if (item.deleted) {
     library_state.library_deleted_items++;
-    library_state.library_entries.push(build_deleted_entry(item, change_type));
+    library_state.library_entries.push(
+      build_deleted_entry(item, change_type, library_state.library_name),
+    );
     library_state.failed_items = clear_item_failure(library_state.failed_items, item.item_id);
     return;
   }
@@ -116,7 +120,13 @@ export async function process_delta_item(
   }
 
   library_state.library_entries.push(
-    build_stored_entry(item, result.storage_key, result.checksum, change_type),
+    build_stored_entry(
+      item,
+      result.storage_key,
+      result.checksum,
+      change_type,
+      library_state.library_name,
+    ),
   );
   library_state.failed_items = clear_item_failure(library_state.failed_items, item.item_id);
   tracking.previous_path_by_file_id[item.item_id] = item.parent_path;

--- a/packages/sharepoint/src/services/sharepoint-restore-content.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-content.ts
@@ -1,0 +1,112 @@
+/**
+ * Fetching and decrypting a manifest entry's stored blob for restore.
+ *
+ * Two paths exist for the same job: files at or above the streaming threshold
+ * are decrypted in chunks, everything else is buffered. Both verify the
+ * plaintext SHA-256 against the manifest before the content is handed back, so
+ * a corrupted or truncated blob is skipped rather than uploaded over a good
+ * file. A failed authentication tag is raised as `SharePointDecryptAuthError`
+ * because it means the wrong key or tampered ciphertext -- an operator-visible
+ * condition, not a per-file hiccup to log and move past.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { SharePointManifestEntry, TenantContext } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import {
+  should_stream_restore,
+  stream_decrypt_from_storage,
+  verify_streaming_checksum,
+} from '@/services/sharepoint-restore-streaming';
+
+/** Thrown when ciphertext decrypts with AES-GCM but fails the authentication tag check. */
+export class SharePointDecryptAuthError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SharePointDecryptAuthError';
+  }
+}
+
+/** Returns the entry's verified plaintext, or undefined when it cannot be restored. */
+export async function download_and_decrypt(
+  ctx: TenantContext,
+  entry: SharePointManifestEntry,
+): Promise<Buffer | undefined> {
+  if (!entry.storage_key) return undefined;
+
+  return should_stream_restore(entry)
+    ? stream_download_and_decrypt(ctx, entry)
+    : buffered_download_and_decrypt(ctx, entry);
+}
+
+async function stream_download_and_decrypt(
+  ctx: TenantContext,
+  entry: SharePointManifestEntry,
+): Promise<Buffer | undefined> {
+  try {
+    const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key!);
+    if (!verify_streaming_checksum(entry, sha256_hex)) return undefined;
+    return content;
+  } catch (err) {
+    if (is_gcm_auth_failure(err)) {
+      throw new SharePointDecryptAuthError(`AES-GCM authentication failed for ${entry.file_name}`, {
+        cause: err,
+      });
+    }
+    logger.warn(
+      `Streaming decrypt failed for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+async function buffered_download_and_decrypt(
+  ctx: TenantContext,
+  entry: SharePointManifestEntry,
+): Promise<Buffer | undefined> {
+  let encrypted: Buffer;
+  try {
+    encrypted = await ctx.storage.get(entry.storage_key!);
+  } catch (err) {
+    logger.warn(
+      `Missing or unreadable blob for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+
+  try {
+    const content = ctx.decrypt(encrypted);
+    const expected = entry.checksum;
+    if (!expected || !plaintext_sha256_equals_expected(content, expected)) {
+      logger.warn(
+        expected
+          ? `Checksum mismatch after decrypt for ${entry.file_name}; skipping restore`
+          : `Missing checksum for ${entry.file_name}; skipping restore`,
+      );
+      return undefined;
+    }
+    return content;
+  } catch (err) {
+    if (is_gcm_auth_failure(err)) {
+      throw new SharePointDecryptAuthError(`AES-GCM authentication failed for ${entry.file_name}`, {
+        cause: err,
+      });
+    }
+    logger.warn(
+      `Failed to decrypt ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+function is_gcm_auth_failure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  return msg.includes('Unsupported state') || lower.includes('auth');
+}
+
+function plaintext_sha256_equals_expected(content: Buffer, expected_hex: string): boolean {
+  const actual_hex = createHash('sha256').update(content).digest('hex');
+  if (actual_hex.length !== expected_hex.length) return false;
+  return timingSafeEqual(Buffer.from(actual_hex, 'utf8'), Buffer.from(expected_hex, 'utf8'));
+}

--- a/packages/sharepoint/src/services/sharepoint-restore-target.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-target.ts
@@ -19,34 +19,54 @@ import type { SharePointDocumentLibrary } from '@wisecom/atlas-types';
 /**
  * Picks the library in `target_libraries` that should receive an entry backed
  * up from `library_name`. Returns undefined when the choice is ambiguous.
+ *
+ * `single_source_library` says whether everything being restored came from one
+ * library. Only then may an unmatched name fall through to a lone target
+ * library: collapsing several source libraries into one destination merges
+ * their trees, and two files sharing a drive-relative path would land on top of
+ * each other -- destroying the restore's own output under `--conflict replace`.
  */
 export function resolve_destination_library(
   library_name: string | undefined,
   target_libraries: readonly SharePointDocumentLibrary[],
+  single_source_library: boolean,
 ): SharePointDocumentLibrary | undefined {
   if (library_name) {
-    const wanted = library_name.toLowerCase();
-    const match = target_libraries.find((lib) => lib.drive_name.toLowerCase() === wanted);
-    if (match) return match;
+    const wanted = fold_name(library_name);
+    const matches = target_libraries.filter((lib) => fold_name(lib.drive_name) === wanted);
+    // Two libraries can carry the same display name; picking either is a guess.
+    if (matches.length === 1) return matches[0];
+    if (matches.length > 1) return undefined;
   }
 
   // Single-library site: the destination is unambiguous whatever it is called.
-  if (target_libraries.length === 1) return target_libraries[0];
+  if (single_source_library && target_libraries.length === 1) return target_libraries[0];
 
   return undefined;
 }
 
+/**
+ * Folds a library name for comparison. NFC because Graph returns whatever form
+ * the client that created the library used, and `toLowerCase` rather than its
+ * locale-aware twin, which maps `I` to a dotless `i` under a Turkish locale.
+ */
+function fold_name(name: string): string {
+  return name.normalize('NFC').trim().toLowerCase();
+}
+
 /** Explains an unresolved destination, listing what the target site does offer. */
 export function describe_unresolved_destination(
-  file_name: string,
   library_name: string | undefined,
   target_libraries: readonly SharePointDocumentLibrary[],
+  single_source_library: boolean,
 ): string {
   const source = library_name ? `library "${library_name}"` : 'an unnamed library';
   const candidates = target_libraries.map((lib) => `"${lib.drive_name}"`).join(', ');
+  const remedy = single_source_library
+    ? 'Restore into a site whose library carries that name, or into a site with a single document library.'
+    : 'This snapshot spans several libraries, so it cannot be folded into one destination: restore it into a site whose libraries carry the same names, or one library at a time with --file-filter.';
   return (
-    `${file_name}: no destination library in the target site matches ${source} ` +
-    `(target has ${candidates}). Create a library with that name, or restore ` +
-    `with --file-filter into a site that has one.`
+    `No library in the target site matches source ${source} (target has ${candidates}); ` +
+    `its files were skipped. ${remedy}`
   );
 }

--- a/packages/sharepoint/src/services/sharepoint-restore-target.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-target.ts
@@ -1,0 +1,52 @@
+/**
+ * Destination routing for cross-site restores.
+ *
+ * A manifest entry records the `drive_id` of the library it was backed up
+ * from. That id is only meaningful inside the source site: Graph addresses an
+ * upload as `/sites/{site}/drives/{drive}/...` and the drive id wins, so
+ * reusing it while pointing at another site writes into the *source* library.
+ * A cross-site restore therefore has to pick a library that belongs to the
+ * target site, and must refuse rather than guess when it cannot.
+ *
+ * Library names are locale-dependent (a Finnish tenant's default library is
+ * `Tiedostot`, an English one's is `Documents`), so an exact name match cannot
+ * be the only rule -- the common single-library case is resolved by position
+ * instead.
+ */
+
+import type { SharePointDocumentLibrary } from '@wisecom/atlas-types';
+
+/**
+ * Picks the library in `target_libraries` that should receive an entry backed
+ * up from `library_name`. Returns undefined when the choice is ambiguous.
+ */
+export function resolve_destination_library(
+  library_name: string | undefined,
+  target_libraries: readonly SharePointDocumentLibrary[],
+): SharePointDocumentLibrary | undefined {
+  if (library_name) {
+    const wanted = library_name.toLowerCase();
+    const match = target_libraries.find((lib) => lib.drive_name.toLowerCase() === wanted);
+    if (match) return match;
+  }
+
+  // Single-library site: the destination is unambiguous whatever it is called.
+  if (target_libraries.length === 1) return target_libraries[0];
+
+  return undefined;
+}
+
+/** Explains an unresolved destination, listing what the target site does offer. */
+export function describe_unresolved_destination(
+  file_name: string,
+  library_name: string | undefined,
+  target_libraries: readonly SharePointDocumentLibrary[],
+): string {
+  const source = library_name ? `library "${library_name}"` : 'an unnamed library';
+  const candidates = target_libraries.map((lib) => `"${lib.drive_name}"`).join(', ');
+  return (
+    `${file_name}: no destination library in the target site matches ${source} ` +
+    `(target has ${candidates}). Create a library with that name, or restore ` +
+    `with --file-filter into a site that has one.`
+  );
+}

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'inversify';
 import type {
+  SharePointDocumentLibrary,
   SharePointSiteConnector,
   SharePointManifestEntry,
   SharePointManifestRepository,
@@ -25,6 +26,15 @@ import {
 } from '@/services/sharepoint-restore-target';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
+
+/** Per-run state deciding which library each entry is written to. */
+interface EntryRouting {
+  readonly cross_site: boolean;
+  readonly target_libraries: readonly SharePointDocumentLibrary[];
+  readonly single_source_library: boolean;
+  /** Memoised destination per source library id; undefined means unresolvable. */
+  readonly destination_by_source_drive: Map<string, string | undefined>;
+}
 
 @injectable()
 export class SharePointRestoreService implements SharePointRestoreUseCase {
@@ -54,11 +64,11 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
 
       // Entry drive ids belong to the source site, so a cross-site restore has to
       // re-point every upload at a library of the target site.
-      const target_libraries =
-        target_site === site_id
-          ? []
-          : await this._connector.list_document_libraries(tenant_id, target_site);
-      if (target_site !== site_id && target_libraries.length === 0) {
+      const cross_site = target_site !== site_id;
+      const target_libraries = cross_site
+        ? await this._connector.list_document_libraries(tenant_id, target_site)
+        : [];
+      if (cross_site && target_libraries.length === 0) {
         throw new Error(
           `Target site ${target_site} has no document libraries to restore into; ` +
             `refusing to fall back to the source site`,
@@ -72,41 +82,38 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       const errors: string[] = [];
 
       const restorable = [...entries].filter((e) => e.change_type !== 'deleted' && e.storage_key);
+      const routing: EntryRouting = {
+        cross_site,
+        target_libraries,
+        // Resolved once per source library rather than per file: the answer is the
+        // same for every entry of a library, and an unresolvable one should be
+        // reported once instead of once per skipped file.
+        destination_by_source_drive: new Map<string, string | undefined>(),
+        single_source_library: new Set(restorable.map((e) => e.drive_id)).size === 1,
+      };
 
       for (const entry of restorable) {
-        const destination =
-          target_site === site_id
-            ? { drive_id: entry.drive_id, drive_name: entry.library_name ?? '' }
-            : resolve_destination_library(entry.library_name, target_libraries);
-
-        if (!destination) {
-          errors.push(
-            describe_unresolved_destination(entry.file_name, entry.library_name, target_libraries),
-          );
+        const destination_drive_id = this.resolve_entry_destination(entry, routing, errors);
+        if (!destination_drive_id) {
           files_skipped++;
           continue;
         }
 
-        await this.restore_single_entry(
+        const outcome = await this.restore_single_entry(
           tenant_id,
           target_site,
-          destination.drive_id,
+          destination_drive_id,
           conflict,
           ctx,
           entry,
           folder_ids,
-          () => {
-            files_restored++;
-          },
-          () => {
-            files_skipped++;
-          },
           errors,
         );
+        if (outcome === 'restored') files_restored++;
+        else files_skipped++;
       }
 
-      const unique_drive_folder_keys = new Set([...folder_ids.keys()].map((k) => k));
-      const folders_created = Math.max(0, unique_drive_folder_keys.size);
+      const folders_created = folder_ids.size;
 
       return {
         snapshot_id: options.snapshot_id,
@@ -120,6 +127,47 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     }
   }
 
+  /**
+   * Destination drive for one entry, or undefined when it cannot be placed.
+   * Resolution is memoised per source library, so an unresolvable library is
+   * reported once rather than once per file it holds.
+   */
+  private resolve_entry_destination(
+    entry: SharePointManifestEntry,
+    routing: EntryRouting,
+    errors: string[],
+  ): string | undefined {
+    if (!routing.cross_site) {
+      if (!entry.drive_id) {
+        errors.push(`${entry.file_name}: manifest entry records no library; skipped`);
+      }
+      return entry.drive_id;
+    }
+
+    const { destination_by_source_drive, target_libraries, single_source_library } = routing;
+    if (destination_by_source_drive.has(entry.drive_id)) {
+      return destination_by_source_drive.get(entry.drive_id);
+    }
+
+    const destination = resolve_destination_library(
+      entry.library_name,
+      target_libraries,
+      single_source_library,
+    )?.drive_id;
+    destination_by_source_drive.set(entry.drive_id, destination);
+    if (!destination) {
+      errors.push(
+        describe_unresolved_destination(
+          entry.library_name,
+          target_libraries,
+          single_source_library,
+        ),
+      );
+    }
+    return destination;
+  }
+
+  /** Restores one entry, reporting whether it landed or was skipped. */
   private async restore_single_entry(
     tenant_id: string,
     target_site: string,
@@ -128,10 +176,8 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     ctx: TenantContext,
     entry: SharePointManifestEntry,
     folder_ids: Map<string, string>,
-    on_restored: () => void,
-    on_skipped: () => void,
     errors: string[],
-  ): Promise<void> {
+  ): Promise<'restored' | 'skipped'> {
     try {
       const parent_id = await this.ensure_folder_path(
         tenant_id,
@@ -145,14 +191,15 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         errors.push(
           `Could not create folder path: ${entry.parent_path} in drive ${destination_drive_id}`,
         );
-        on_skipped();
-        return;
+        return 'skipped';
       }
 
       const content = await download_and_decrypt(ctx, entry);
       if (!content) {
-        on_skipped();
-        return;
+        // The specific cause is already logged; recording it here is what makes a
+        // restore that verified nothing exit non-zero instead of reporting success.
+        errors.push(`${entry.file_name}: content unavailable or failed verification; skipped`);
+        return 'skipped';
       }
 
       if (content.length <= SMALL_FILE_LIMIT) {
@@ -177,22 +224,18 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         );
       }
 
-      on_restored();
       logger.info(
         `Restored: ${entry.parent_path}/${entry.file_name} (drive: ${destination_drive_id})`,
       );
+      return 'restored';
     } catch (err) {
-      if (err instanceof SharePointDecryptAuthError) {
-        const msg = `${entry.file_name}: ${err.message}`;
-        errors.push(msg);
-        on_skipped();
-        logger.warn(`Skipped ${entry.file_name}: ${msg}`);
-        return;
-      }
-      const msg = `${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`;
+      const msg =
+        err instanceof SharePointDecryptAuthError
+          ? `${entry.file_name}: ${err.message}`
+          : `${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`;
       errors.push(msg);
-      on_skipped();
       logger.warn(`Skipped ${entry.file_name}: ${msg}`);
+      return 'skipped';
     }
   }
 
@@ -204,7 +247,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
     return entries.filter(
       (e) =>
-        filter_set.has(e.file_id) ||
+        filter_set.has(e.file_id.toLowerCase()) ||
         filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
     );
   }

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -1,4 +1,3 @@
-import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointSiteConnector,
@@ -17,20 +16,15 @@ import {
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
-  should_stream_restore,
-  stream_decrypt_from_storage,
-  verify_streaming_checksum,
-} from '@/services/sharepoint-restore-streaming';
+  download_and_decrypt,
+  SharePointDecryptAuthError,
+} from '@/services/sharepoint-restore-content';
+import {
+  describe_unresolved_destination,
+  resolve_destination_library,
+} from '@/services/sharepoint-restore-target';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
-
-/** Thrown when ciphertext decrypts with AES-GCM but fails the authentication tag check. */
-export class SharePointDecryptAuthError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = 'SharePointDecryptAuthError';
-  }
-}
 
 @injectable()
 export class SharePointRestoreService implements SharePointRestoreUseCase {
@@ -58,6 +52,19 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       const conflict = options.conflict_behavior ?? 'rename';
       const entries = this.filter_entries(manifest.entries, options.file_filter);
 
+      // Entry drive ids belong to the source site, so a cross-site restore has to
+      // re-point every upload at a library of the target site.
+      const target_libraries =
+        target_site === site_id
+          ? []
+          : await this._connector.list_document_libraries(tenant_id, target_site);
+      if (target_site !== site_id && target_libraries.length === 0) {
+        throw new Error(
+          `Target site ${target_site} has no document libraries to restore into; ` +
+            `refusing to fall back to the source site`,
+        );
+      }
+
       // Folder cache keyed by "drive_id:path" since entries span multiple document libraries
       const folder_ids = new Map<string, string>();
       let files_restored = 0;
@@ -67,9 +74,23 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       const restorable = [...entries].filter((e) => e.change_type !== 'deleted' && e.storage_key);
 
       for (const entry of restorable) {
+        const destination =
+          target_site === site_id
+            ? { drive_id: entry.drive_id, drive_name: entry.library_name ?? '' }
+            : resolve_destination_library(entry.library_name, target_libraries);
+
+        if (!destination) {
+          errors.push(
+            describe_unresolved_destination(entry.file_name, entry.library_name, target_libraries),
+          );
+          files_skipped++;
+          continue;
+        }
+
         await this.restore_single_entry(
           tenant_id,
           target_site,
+          destination.drive_id,
           conflict,
           ctx,
           entry,
@@ -102,6 +123,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
   private async restore_single_entry(
     tenant_id: string,
     target_site: string,
+    destination_drive_id: string,
     conflict: string,
     ctx: TenantContext,
     entry: SharePointManifestEntry,
@@ -114,20 +136,20 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       const parent_id = await this.ensure_folder_path(
         tenant_id,
         target_site,
-        entry.drive_id,
+        destination_drive_id,
         entry.parent_path,
         folder_ids,
       );
 
       if (parent_id === undefined) {
         errors.push(
-          `Could not create folder path: ${entry.parent_path} in drive ${entry.drive_id}`,
+          `Could not create folder path: ${entry.parent_path} in drive ${destination_drive_id}`,
         );
         on_skipped();
         return;
       }
 
-      const content = await this.download_and_decrypt(ctx, entry);
+      const content = await download_and_decrypt(ctx, entry);
       if (!content) {
         on_skipped();
         return;
@@ -137,7 +159,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         await this._connector.upload_small_file(
           tenant_id,
           target_site,
-          entry.drive_id,
+          destination_drive_id,
           parent_id,
           entry.file_name,
           content,
@@ -147,7 +169,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         await this._connector.upload_large_file(
           tenant_id,
           target_site,
-          entry.drive_id,
+          destination_drive_id,
           parent_id,
           entry.file_name,
           content,
@@ -156,7 +178,9 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       }
 
       on_restored();
-      logger.info(`Restored: ${entry.parent_path}/${entry.file_name} (drive: ${entry.drive_id})`);
+      logger.info(
+        `Restored: ${entry.parent_path}/${entry.file_name} (drive: ${destination_drive_id})`,
+      );
     } catch (err) {
       if (err instanceof SharePointDecryptAuthError) {
         const msg = `${entry.file_name}: ${err.message}`;
@@ -234,90 +258,4 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
 
     return parent_id;
   }
-
-  private async download_and_decrypt(
-    ctx: TenantContext,
-    entry: SharePointManifestEntry,
-  ): Promise<Buffer | undefined> {
-    if (!entry.storage_key) return undefined;
-
-    if (should_stream_restore(entry)) {
-      return this.stream_download_and_decrypt(ctx, entry);
-    }
-
-    return this.buffered_download_and_decrypt(ctx, entry);
-  }
-
-  private async stream_download_and_decrypt(
-    ctx: TenantContext,
-    entry: SharePointManifestEntry,
-  ): Promise<Buffer | undefined> {
-    try {
-      const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key!);
-      if (!verify_streaming_checksum(entry, sha256_hex)) return undefined;
-      return content;
-    } catch (err) {
-      if (is_gcm_auth_failure(err)) {
-        throw new SharePointDecryptAuthError(
-          `AES-GCM authentication failed for ${entry.file_name}`,
-          { cause: err },
-        );
-      }
-      logger.warn(
-        `Streaming decrypt failed for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  private async buffered_download_and_decrypt(
-    ctx: TenantContext,
-    entry: SharePointManifestEntry,
-  ): Promise<Buffer | undefined> {
-    let encrypted: Buffer;
-    try {
-      encrypted = await ctx.storage.get(entry.storage_key!);
-    } catch (err) {
-      logger.warn(
-        `Missing or unreadable blob for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-    try {
-      const content = ctx.decrypt(encrypted);
-      const expected = entry.checksum;
-      if (!expected || !plaintext_sha256_equals_expected(content, expected)) {
-        logger.warn(
-          expected
-            ? `Checksum mismatch after decrypt for ${entry.file_name}; skipping restore`
-            : `Missing checksum for ${entry.file_name}; skipping restore`,
-        );
-        return undefined;
-      }
-      return content;
-    } catch (err) {
-      if (is_gcm_auth_failure(err)) {
-        throw new SharePointDecryptAuthError(
-          `AES-GCM authentication failed for ${entry.file_name}`,
-          { cause: err },
-        );
-      }
-      logger.warn(
-        `Failed to decrypt ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-}
-
-function is_gcm_auth_failure(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  const lower = msg.toLowerCase();
-  return msg.includes('Unsupported state') || lower.includes('auth');
-}
-
-function plaintext_sha256_equals_expected(content: Buffer, expected_hex: string): boolean {
-  const actual_hex = createHash('sha256').update(content).digest('hex');
-  if (actual_hex.length !== expected_hex.length) return false;
-  return timingSafeEqual(Buffer.from(actual_hex, 'utf8'), Buffer.from(expected_hex, 'utf8'));
 }

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
@@ -166,6 +166,33 @@ describe('SharePointRestoreService cross-site routing', () => {
     expect(result.errors[0]).toContain('Tiedostot');
   });
 
+  it('reports an unresolvable library once, not once per skipped file', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-docs', drive_name: 'Documents' },
+      { drive_id: 'target-archive', drive_name: 'Archive' },
+    ]);
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue({
+      snapshot_id: 'sp-snap-1',
+      site_id: SOURCE_SITE,
+      created_at: new Date('2026-03-15T10:00:00Z'),
+      total_files: 3,
+      entries: [
+        make_entry({ file_id: 'a', file_name: 'a.docx' }),
+        make_entry({ file_id: 'b', file_name: 'b.docx' }),
+        make_entry({ file_id: 'c', file_name: 'c.docx' }),
+      ],
+    } as never);
+
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+    });
+
+    // Every file is still counted, but the operator reads one explanation.
+    expect(result.files_skipped).toBe(3);
+    expect(result.errors).toHaveLength(1);
+  });
+
   it('fails the run when the target site has no document libraries', async () => {
     vi.mocked(connector.list_document_libraries).mockResolvedValue([]);
 
@@ -177,6 +204,59 @@ describe('SharePointRestoreService cross-site routing', () => {
     ).rejects.toThrow(/no document libraries/i);
 
     expect(connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it("refuses to fold several source libraries into the target's only library", async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-docs', drive_name: 'Documents' },
+    ]);
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue({
+      snapshot_id: 'sp-snap-1',
+      site_id: SOURCE_SITE,
+      created_at: new Date('2026-03-15T10:00:00Z'),
+      total_files: 2,
+      // Same drive-relative path in two libraries: merging them would make the
+      // second file overwrite the first under --conflict replace.
+      entries: [
+        make_entry({ file_id: 'a', drive_id: 'source-docs', library_name: 'Documents' }),
+        make_entry({ file_id: 'b', drive_id: 'source-policies', library_name: 'Policies' }),
+      ],
+    } as never);
+
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+      conflict_behavior: 'replace',
+    });
+
+    // "Documents" still matches by name; "Policies" has nowhere to go and is refused.
+    expect(vi.mocked(connector.upload_small_file).mock.calls.map((c) => c[2])).toEqual([
+      'target-docs',
+    ]);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors.join(' ')).toContain('Policies');
+  });
+
+  it('reports an error when a file fails verification, so the run cannot exit 0', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-drive', drive_name: 'Documents' },
+    ]);
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue({
+      snapshot_id: 'sp-snap-1',
+      site_id: SOURCE_SITE,
+      created_at: new Date('2026-03-15T10:00:00Z'),
+      total_files: 1,
+      entries: [make_entry({ checksum: 'a'.repeat(64) })],
+    } as never);
+
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+    });
+
+    expect(connector.upload_small_file).not.toHaveBeenCalled();
+    expect(result.files_restored).toBe(0);
+    expect(result.errors).toHaveLength(1);
   });
 
   it('restores in place using the recorded drive when no target site is given', async () => {

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
@@ -1,0 +1,210 @@
+import { createHash } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { SharePointRestoreService } from '@/services/sharepoint-restore.service';
+import {
+  SHAREPOINT_CONNECTOR_TOKEN,
+  SHAREPOINT_MANIFEST_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@wisecom/atlas-types';
+import type {
+  SharePointManifestEntry,
+  SharePointManifestRepository,
+  SharePointSiteConnector,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+
+vi.mock('@/services/sharepoint-restore-streaming', () => ({
+  should_stream_restore: vi.fn().mockReturnValue(false),
+  stream_decrypt_from_storage: vi.fn(),
+  verify_streaming_checksum: vi.fn().mockReturnValue(true),
+}));
+
+const CONTENT = Buffer.from('restored-file-content');
+const SOURCE_SITE = 'source-site';
+const SOURCE_DRIVE = 'source-drive';
+const TARGET_SITE = 'target-site';
+
+function make_entry(overrides: Partial<SharePointManifestEntry> = {}): SharePointManifestEntry {
+  return {
+    file_id: 'sp-file-1',
+    drive_id: SOURCE_DRIVE,
+    library_name: 'Tiedostot',
+    file_name: 'report.docx',
+    parent_path: '/Reports',
+    size_bytes: CONTENT.length,
+    change_type: 'created',
+    backup_at: '2026-03-15T10:00:00.000Z',
+    storage_key: 'sharepoint/data/source-site/abc',
+    checksum: createHash('sha256').update(CONTENT).digest('hex'),
+    ...overrides,
+  };
+}
+
+describe('SharePointRestoreService cross-site routing', () => {
+  let container: Container;
+  let connector: SharePointSiteConnector;
+  let manifests: SharePointManifestRepository;
+  let service: SharePointRestoreService;
+
+  beforeEach(() => {
+    container = new Container();
+
+    const ctx = {
+      storage: { get: vi.fn().mockResolvedValue(CONTENT) },
+      decrypt: vi.fn((buf: Buffer) => buf),
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+
+    const factory: TenantContextFactory = {
+      create: vi.fn().mockResolvedValue(ctx),
+      create_storage_only: vi.fn(),
+    };
+
+    connector = {
+      list_document_libraries: vi.fn().mockResolvedValue([]),
+      create_folder: vi.fn().mockResolvedValue('folder-id'),
+      upload_small_file: vi.fn().mockResolvedValue(undefined),
+      upload_large_file: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SharePointSiteConnector;
+
+    manifests = {
+      find_by_snapshot: vi.fn().mockResolvedValue({
+        snapshot_id: 'sp-snap-1',
+        site_id: SOURCE_SITE,
+        created_at: new Date('2026-03-15T10:00:00Z'),
+        total_files: 1,
+        entries: [make_entry()],
+      }),
+    } as unknown as SharePointManifestRepository;
+
+    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
+    container.bind(SHAREPOINT_CONNECTOR_TOKEN).toConstantValue(connector);
+    container.bind(SHAREPOINT_MANIFEST_REPOSITORY_TOKEN).toConstantValue(manifests);
+    container.bind(SharePointRestoreService).toSelf();
+
+    service = container.get(SharePointRestoreService);
+  });
+
+  it('uploads into the target site library, never the source drive', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-drive', drive_name: 'Documents' },
+    ]);
+
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+    });
+
+    expect(result.files_restored).toBe(1);
+    expect(connector.upload_small_file).toHaveBeenCalledWith(
+      'tenant',
+      TARGET_SITE,
+      'target-drive',
+      expect.any(String),
+      'report.docx',
+      CONTENT,
+      'rename',
+    );
+    // The source library must not be touched, by site or by drive.
+    const [, site_arg, drive_arg] = vi.mocked(connector.upload_small_file).mock.calls[0]!;
+    expect(site_arg).not.toBe(SOURCE_SITE);
+    expect(drive_arg).not.toBe(SOURCE_DRIVE);
+  });
+
+  it('creates the folder path in the target drive', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-drive', drive_name: 'Documents' },
+    ]);
+
+    await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+    });
+
+    expect(connector.create_folder).toHaveBeenCalledWith(
+      'tenant',
+      TARGET_SITE,
+      'target-drive',
+      'root',
+      'Reports',
+    );
+  });
+
+  it('routes by library name when the target has several libraries', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-archive', drive_name: 'Archive' },
+      { drive_id: 'target-tiedostot', drive_name: 'Tiedostot' },
+    ]);
+
+    await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+    });
+
+    expect(vi.mocked(connector.upload_small_file).mock.calls[0]![2]).toBe('target-tiedostot');
+  });
+
+  it('reports an error instead of guessing when no target library matches', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'target-docs', drive_name: 'Documents' },
+      { drive_id: 'target-archive', drive_name: 'Archive' },
+    ]);
+
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: TARGET_SITE,
+    });
+
+    expect(connector.upload_small_file).not.toHaveBeenCalled();
+    expect(result.files_restored).toBe(0);
+    expect(result.files_skipped).toBe(1);
+    // A non-empty errors array is what drives the CLI's non-zero exit.
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Tiedostot');
+  });
+
+  it('fails the run when the target site has no document libraries', async () => {
+    vi.mocked(connector.list_document_libraries).mockResolvedValue([]);
+
+    await expect(
+      service.restore_sharepoint('tenant', SOURCE_SITE, {
+        snapshot_id: 'sp-snap-1',
+        target_site_id: TARGET_SITE,
+      }),
+    ).rejects.toThrow(/no document libraries/i);
+
+    expect(connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it('restores in place using the recorded drive when no target site is given', async () => {
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+    });
+
+    expect(result.files_restored).toBe(1);
+    expect(connector.upload_small_file).toHaveBeenCalledWith(
+      'tenant',
+      SOURCE_SITE,
+      SOURCE_DRIVE,
+      expect.any(String),
+      'report.docx',
+      CONTENT,
+      'rename',
+    );
+    // Same-site restore must not pay for a library lookup it cannot use.
+    expect(connector.list_document_libraries).not.toHaveBeenCalled();
+  });
+
+  it('treats an explicit target equal to the source as an in-place restore', async () => {
+    const result = await service.restore_sharepoint('tenant', SOURCE_SITE, {
+      snapshot_id: 'sp-snap-1',
+      target_site_id: SOURCE_SITE,
+    });
+
+    expect(result.files_restored).toBe(1);
+    expect(vi.mocked(connector.upload_small_file).mock.calls[0]![2]).toBe(SOURCE_DRIVE);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-target.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-target.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import type { SharePointDocumentLibrary } from '@wisecom/atlas-types';
+import {
+  describe_unresolved_destination,
+  resolve_destination_library,
+} from '@/services/sharepoint-restore-target';
+
+function lib(drive_id: string, drive_name: string): SharePointDocumentLibrary {
+  return { drive_id, drive_name };
+}
+
+describe('resolve_destination_library', () => {
+  it('matches the target library that carries the same name', () => {
+    const target = [lib('t-assets', 'Site Assets'), lib('t-docs', 'Documents')];
+
+    expect(resolve_destination_library('Documents', target)).toEqual(lib('t-docs', 'Documents'));
+  });
+
+  it('matches names case-insensitively', () => {
+    const target = [lib('t-docs', 'Shared Documents'), lib('t-other', 'Archive')];
+
+    expect(resolve_destination_library('shared documents', target)?.drive_id).toBe('t-docs');
+  });
+
+  it('uses the only library when the target site has exactly one', () => {
+    // Real tenants localise the default library ("Tiedostot" vs "Documents"),
+    // so a single-library target must resolve by position, not by name.
+    expect(resolve_destination_library('Tiedostot', [lib('t-docs', 'Documents')])?.drive_id).toBe(
+      't-docs',
+    );
+  });
+
+  it('resolves a single-library target even when the source name is unknown', () => {
+    expect(resolve_destination_library(undefined, [lib('t-docs', 'Documents')])?.drive_id).toBe(
+      't-docs',
+    );
+  });
+
+  it('refuses to guess between several non-matching libraries', () => {
+    const target = [lib('t-docs', 'Documents'), lib('t-archive', 'Archive')];
+
+    expect(resolve_destination_library('Tiedostot', target)).toBeUndefined();
+  });
+
+  it('refuses to guess when the source library name was never recorded', () => {
+    const target = [lib('t-docs', 'Documents'), lib('t-archive', 'Archive')];
+
+    expect(resolve_destination_library(undefined, target)).toBeUndefined();
+  });
+
+  it('never resolves against an empty target site', () => {
+    expect(resolve_destination_library('Documents', [])).toBeUndefined();
+  });
+});
+
+describe('describe_unresolved_destination', () => {
+  it('names the source library and the available candidates', () => {
+    const message = describe_unresolved_destination('report.docx', 'Tiedostot', [
+      lib('t-docs', 'Documents'),
+      lib('t-archive', 'Archive'),
+    ]);
+
+    expect(message).toContain('report.docx');
+    expect(message).toContain('"Tiedostot"');
+    expect(message).toContain('"Documents", "Archive"');
+  });
+});

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-target.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-target.test.ts
@@ -9,59 +9,122 @@ function lib(drive_id: string, drive_name: string): SharePointDocumentLibrary {
   return { drive_id, drive_name };
 }
 
+const ONE_SOURCE_LIBRARY = true;
+const MANY_SOURCE_LIBRARIES = false;
+
 describe('resolve_destination_library', () => {
   it('matches the target library that carries the same name', () => {
     const target = [lib('t-assets', 'Site Assets'), lib('t-docs', 'Documents')];
 
-    expect(resolve_destination_library('Documents', target)).toEqual(lib('t-docs', 'Documents'));
+    expect(resolve_destination_library('Documents', target, ONE_SOURCE_LIBRARY)).toEqual(
+      lib('t-docs', 'Documents'),
+    );
   });
 
   it('matches names case-insensitively', () => {
     const target = [lib('t-docs', 'Shared Documents'), lib('t-other', 'Archive')];
 
-    expect(resolve_destination_library('shared documents', target)?.drive_id).toBe('t-docs');
+    expect(
+      resolve_destination_library('shared documents', target, ONE_SOURCE_LIBRARY)?.drive_id,
+    ).toBe('t-docs');
+  });
+
+  it('matches across Unicode forms and stray whitespace', () => {
+    // "Työtiedostot" composed (NFC) in the manifest, decomposed (NFD) from Graph.
+    const target = [lib('t-docs', 'Työtiedostot'.normalize('NFD')), lib('t-other', 'Archive')];
+
+    expect(
+      resolve_destination_library(' Työtiedostot '.normalize('NFC'), target, ONE_SOURCE_LIBRARY)
+        ?.drive_id,
+    ).toBe('t-docs');
   });
 
   it('uses the only library when the target site has exactly one', () => {
     // Real tenants localise the default library ("Tiedostot" vs "Documents"),
     // so a single-library target must resolve by position, not by name.
-    expect(resolve_destination_library('Tiedostot', [lib('t-docs', 'Documents')])?.drive_id).toBe(
-      't-docs',
-    );
+    expect(
+      resolve_destination_library('Tiedostot', [lib('t-docs', 'Documents')], ONE_SOURCE_LIBRARY)
+        ?.drive_id,
+    ).toBe('t-docs');
   });
 
   it('resolves a single-library target even when the source name is unknown', () => {
-    expect(resolve_destination_library(undefined, [lib('t-docs', 'Documents')])?.drive_id).toBe(
-      't-docs',
+    expect(
+      resolve_destination_library(undefined, [lib('t-docs', 'Documents')], ONE_SOURCE_LIBRARY)
+        ?.drive_id,
+    ).toBe('t-docs');
+  });
+
+  it('refuses the lone-library fallback when the snapshot spans several libraries', () => {
+    // Folding several source libraries into one destination merges their trees:
+    // two files sharing a path would overwrite each other under --conflict replace.
+    expect(
+      resolve_destination_library('Tiedostot', [lib('t-docs', 'Documents')], MANY_SOURCE_LIBRARIES),
+    ).toBeUndefined();
+  });
+
+  it('still matches by name when the snapshot spans several libraries', () => {
+    const target = [lib('t-docs', 'Documents'), lib('t-archive', 'Archive')];
+
+    expect(resolve_destination_library('Archive', target, MANY_SOURCE_LIBRARIES)?.drive_id).toBe(
+      't-archive',
     );
+  });
+
+  it('refuses when two target libraries share the matched name', () => {
+    const target = [lib('t-docs-a', 'Documents'), lib('t-docs-b', 'documents')];
+
+    expect(resolve_destination_library('Documents', target, ONE_SOURCE_LIBRARY)).toBeUndefined();
   });
 
   it('refuses to guess between several non-matching libraries', () => {
     const target = [lib('t-docs', 'Documents'), lib('t-archive', 'Archive')];
 
-    expect(resolve_destination_library('Tiedostot', target)).toBeUndefined();
+    expect(resolve_destination_library('Tiedostot', target, ONE_SOURCE_LIBRARY)).toBeUndefined();
   });
 
   it('refuses to guess when the source library name was never recorded', () => {
     const target = [lib('t-docs', 'Documents'), lib('t-archive', 'Archive')];
 
-    expect(resolve_destination_library(undefined, target)).toBeUndefined();
+    expect(resolve_destination_library(undefined, target, ONE_SOURCE_LIBRARY)).toBeUndefined();
   });
 
   it('never resolves against an empty target site', () => {
-    expect(resolve_destination_library('Documents', [])).toBeUndefined();
+    expect(resolve_destination_library('Documents', [], ONE_SOURCE_LIBRARY)).toBeUndefined();
   });
 });
 
 describe('describe_unresolved_destination', () => {
   it('names the source library and the available candidates', () => {
-    const message = describe_unresolved_destination('report.docx', 'Tiedostot', [
-      lib('t-docs', 'Documents'),
-      lib('t-archive', 'Archive'),
-    ]);
+    const message = describe_unresolved_destination(
+      'Tiedostot',
+      [lib('t-docs', 'Documents'), lib('t-archive', 'Archive')],
+      ONE_SOURCE_LIBRARY,
+    );
 
-    expect(message).toContain('report.docx');
     expect(message).toContain('"Tiedostot"');
     expect(message).toContain('"Documents", "Archive"');
+  });
+
+  it('still reads sensibly when the source library name was never recorded', () => {
+    const message = describe_unresolved_destination(
+      undefined,
+      [lib('t-docs', 'Documents')],
+      ONE_SOURCE_LIBRARY,
+    );
+
+    expect(message).toContain('unnamed library');
+    expect(message).not.toContain('undefined');
+  });
+
+  it('explains that a multi-library snapshot cannot be folded into one library', () => {
+    const message = describe_unresolved_destination(
+      'Policies',
+      [lib('t-docs', 'Documents')],
+      MANY_SOURCE_LIBRARIES,
+    );
+
+    expect(message).toContain('spans several libraries');
+    expect(message).toContain('--file-filter');
   });
 });


### PR DESCRIPTION
Closes #71

## Problem

`--target-site` resolved the target, logged it, and then wrote every file back into the **source** library. Graph addresses an upload as `/sites/{site}/drives/{drive}/...` and the drive id wins, so passing the target site together with the entry's stored `drive_id` silently redirected the whole restore.

This is worse than a no-op. With the default `--conflict rename` the source library quietly accumulated duplicates; with `--conflict replace` a restore aimed at a scratch site would have **overwritten live production files**. Cross-site restore is exactly the "recover somewhere safe and inspect before promoting" workflow, so the failure landed on the safety-conscious path — and reported `Restore completed successfully` while doing it.

## Fix

A cross-site restore now resolves a destination library **inside the target site**, per entry:

1. **Same library name** (case-insensitive) — keeps a multi-library site's structure when names line up.
2. **The only library** — if the target has exactly one, it takes everything.
3. **Neither → refuse.** The file is reported with the candidates listed, and the run exits non-zero. Never a guess, never the source library.

A target site with **no** libraries fails the run before anything is uploaded. In-place restore is byte-identical to before and skips the library lookup entirely.

Why rule 2 exists: library names are localised. The source site in our tenant calls its default library `Tiedostot`, the target calls it `Documents` — name matching alone would fail the most common real case, so a single-library target is resolved by position.

Manifest entries now record `library_name`. The field was already on the type but nothing ever populated it; it is what makes rule 1 work for multi-library sites. Older snapshots carry no name and fall back to rule 2.

## Verified live

Against the real tenant, restoring `WisecomIntranet` (`Tiedostot`) → `WisecomOy` (`Documents`):

| | before fix (from the issue) | after |
| --- | --- | --- |
| upload drive | `b!KKlNBw…` — the **source** library | `b!St_j3V…` — the **target** library |
| target site | `[]`, nothing arrived | files present at `/Tietoturva/Test/` |
| source library | 5 renamed duplicates appeared | **unchanged**, checksum `36a89814168b` before and after |

Both refusal paths exercised through the CLI (library listing faulted temporarily, injection reverted):

| scenario | result | exit |
| --- | --- | --- |
| target has `Documents` + `Archive`, source is `Tiedostot` | no upload, candidates named | **1** |
| target has no libraries | run fails before uploading | **1** |
| happy path | 2 files restored into target | 0 |

Tenant left exactly as found: restored copies deleted, source untouched, probe scripts removed.

## Tests

15 new tests. `sharepoint-restore-cross-site.test.ts` asserts the connector receives the target drive and *not* the source one — the assertion that fails on the original bug — plus folder creation in the target drive, name routing across several libraries, the ambiguity error, the empty-target throw, and that in-place restore neither changes behaviour nor calls `list_document_libraries`. `sharepoint-restore-target.test.ts` covers the resolver rules directly.

Full suite green (737 tests), lint, format, docs build.

## Docs

`docs/sharepoint-backup.md` gains a "Where a cross-site restore lands" section with the three rules and a warning about pre-2.1.0-beta snapshots; `docs/reference/cli.md` links it from the option table. The old claim that entries' `drive_id` routes files "to the correct document library automatically" was true only for in-place restore and is corrected.

## Also in this PR

`sharepoint-restore.service.ts` crossed the 300-line rule, so blob download, decryption and checksum verification moved to `sharepoint-restore-content.ts`. Pure move, no behaviour change.

## Audited, not changed

OneDrive's `--target-owner` already lists the **target owner's** drives and ignores the entry's `drive_id`, so it never had this bug. That is the pattern this change brings SharePoint in line with.
