### PR TITLE
fix(sdk): report the Graph cost burned before a failure

### DIFF
--- a/docs/operations/graph-rate-limits.md
+++ b/docs/operations/graph-rate-limits.md
@@ -256,11 +256,14 @@ Key implications for SaaS scheduling:
 Atlas exports the `GRAPH_SERVICE_LIMITS` constant so your SaaS layer can use the same authoritative numbers for scheduling decisions:
 
 ```typescript
-import { GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-sdk';
+import { getGraphCost, GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-sdk';
 import type { OperationCost } from '@wisecom/atlas-sdk';
 
-// After a backup job completes:
-const cost: OperationCost = result.graph_cost;
+// After a backup job finishes -- successfully or not. A run that threw has
+// usually spent MORE quota than one that completed, so cool down on it too.
+const cost: OperationCost | undefined = result?.graph_cost ?? getGraphCost(err);
+if (!cost) return;
+
 const outlook = GRAPH_SERVICE_LIMITS.outlook;
 
 // Estimate cooldown: how much of the 10-min window did we consume?

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -261,6 +261,39 @@ console.log(result.graph_cost);
 
 Methods that report `graph_cost`: `atlas.outlook.backup`, `atlas.outlook.restore`, `atlas.outlook.restoreMailbox`, `atlas.outlook.checkMailboxStatus`.
 
+### Cost when an operation fails
+
+Failures are the most expensive runs a tenant pays for: a delta sync that dies on
+page 400, or a request that spent its whole retry budget against a 429, has burned
+more quota than any successful run in the job. That cost is attached to the thrown
+error and read with `getGraphCost`:
+
+```typescript
+import { createAtlasInstance, getGraphCost } from '@wisecom/atlas-sdk';
+
+try {
+  const result = await atlas.outlook.backup('user@company.com');
+  record_cost(result.graph_cost);
+} catch (err) {
+  // Requests already burned before the failure -- undefined if the error came
+  // from somewhere other than a tracked SDK operation.
+  const cost = getGraphCost(err);
+  if (cost) record_cost(cost);
+  throw err;
+}
+```
+
+The error itself is rethrown unchanged, so `instanceof` checks and existing catch
+filters keep working, and the cost is a non-enumerable property, so error logging
+and serialisation are unaffected. A failure that happened before any Graph call
+reports `requests_total: 0` -- that is a fact worth recording, not a missing value.
+
+::: warning Ignoring this skews your scheduling in the wrong direction
+A scheduler that reads cost only on the success path treats the most expensive
+runs as free, and re-queues the next mailbox into a tenant that is already
+throttled -- producing another 429 and raising the throttle fence again.
+:::
+
 ### OperationCost Type
 
 ```typescript
@@ -310,7 +343,7 @@ See the [Graph API Rate Limits](/operations/graph-rate-limits) page for the full
 A common pattern for SaaS products is to queue one job per mailbox using pg-boss and use `graph_cost` to compute a cooldown before scheduling the next job:
 
 ```typescript
-import { createAtlasInstance, GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-sdk';
+import { createAtlasInstance, getGraphCost, GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-sdk';
 import type { OperationCost } from '@wisecom/atlas-sdk';
 import PgBoss from 'pg-boss';
 
@@ -320,32 +353,43 @@ boss.work('backup-mailbox', async (job) => {
   const { tenant_config, mailbox_id } = job.data;
   const atlas = createAtlasInstance(tenant_config);
 
-  const result = await atlas.outlook.backup(mailbox_id);
-  const cost: OperationCost = result.graph_cost;
+  let cost: OperationCost | undefined;
+  try {
+    const result = await atlas.outlook.backup(mailbox_id);
+    cost = result.graph_cost;
+  } catch (err) {
+    // A failed run has usually burned MORE quota than a successful one. Bill it
+    // and cool down on it, then let pg-boss see the failure.
+    cost = getGraphCost(err);
+    throw err;
+  } finally {
+    if (cost) {
+      // Store per-pool costs for trend analysis
+      await db.query(
+        `INSERT INTO backup_costs
+           (mailbox_id, outlook_requests, identity_requests, elapsed_ms, completed_at)
+         VALUES ($1, $2, $3, $4, NOW())`,
+        [
+          mailbox_id,
+          cost.by_service.outlook?.requests ?? 0,
+          cost.by_service.identity?.requests ?? 0,
+          cost.elapsed_ms,
+        ],
+      );
 
-  // Store per-pool costs for trend analysis
-  await db.query(
-    `INSERT INTO backup_costs
-       (mailbox_id, outlook_requests, identity_requests, elapsed_ms, completed_at)
-     VALUES ($1, $2, $3, $4, NOW())`,
-    [
-      mailbox_id,
-      cost.by_service.outlook?.requests ?? 0,
-      cost.by_service.identity?.requests ?? 0,
-      cost.elapsed_ms,
-    ],
-  );
+      // Compute cooldown from the Outlook pool limit (bottleneck for mail backup)
+      const outlook_limits = GRAPH_SERVICE_LIMITS.outlook;
+      const outlook_used = cost.by_service.outlook?.requests ?? 0;
+      const usage_ratio = outlook_used / outlook_limits.requests_per_window;
+      const cooldown_ms = Math.ceil(usage_ratio * outlook_limits.window_duration_ms);
 
-  // Compute cooldown from the Outlook pool limit (bottleneck for mail backup)
-  const outlook_limits = GRAPH_SERVICE_LIMITS.outlook;
-  const outlook_used = cost.by_service.outlook?.requests ?? 0;
-  const usage_ratio = outlook_used / outlook_limits.requests_per_window;
-  const cooldown_ms = Math.ceil(usage_ratio * outlook_limits.window_duration_ms);
-
-  // Re-enqueue after cooldown
-  await boss.send('backup-mailbox', job.data, {
-    startAfter: new Date(Date.now() + cooldown_ms),
-  });
+      // Re-enqueue after cooldown -- on the failure path this is what stops the
+      // retry from landing straight back on a throttled tenant.
+      await boss.send('backup-mailbox', job.data, {
+        startAfter: new Date(Date.now() + cooldown_ms),
+      });
+    }
+  }
 });
 ```
 
@@ -366,6 +410,7 @@ For future OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant. Y
 - Deletion types: `DeletionResult`
 - Replication types: `ReplicationResult`, `ReplicationStatusRecord`, `StorageTarget`, `StorageTargetConfig`
 - Factory functions: `createAtlasInstance`, `createStorageTarget`
+- Cost helpers: `getGraphCost`
 
 **Graph cost types:**
 
@@ -379,5 +424,6 @@ For future OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant. Y
 | `SharePointServiceLimits` | type  | SharePoint/OneDrive pool limits type                                   |
 | `IdentityServiceLimits`   | type  | Identity pool limits type                                              |
 | `GRAPH_SERVICE_LIMITS`    | value | Frozen official limits constant                                        |
+| `getGraphCost`            | value | Reads the cost burned before a failed operation threw                  |
 | `SyncResult`              | type  | Result of `atlas.outlook.backup` (includes `graph_cost`)                      |
 | `RestoreResult`           | type  | Result of `atlas.outlook.restore` / `restoreMailbox` (includes `graph_cost`) |

--- a/packages/core/src/services/shared/graph-request-context.ts
+++ b/packages/core/src/services/shared/graph-request-context.ts
@@ -18,11 +18,61 @@ const _storage = new AsyncLocalStorage<GraphRequestCounter>();
 /**
  * Runs `fn` inside a fresh cost-tracking context and returns both the result
  * and the accumulated OperationCost for the duration of the call.
+ *
+ * When `fn` rejects, the cost burned before the failure is attached to the
+ * thrown error and readable with {@link get_graph_cost}. Failures are the most
+ * expensive runs a tenant pays for -- a delta sync that dies on page 400, or a
+ * request that spent its whole retry budget against a 429 -- so a scheduler
+ * that only reads cost on success re-queues straight into a throttled tenant.
+ * The original error is rethrown unchanged, so `instanceof` checks and catch
+ * filters on the caller's side keep working.
  */
 export async function run_with_cost_tracking<T>(fn: () => Promise<T>): Promise<[T, OperationCost]> {
   const counter = new GraphRequestCounter();
-  const result = await _storage.run(counter, fn);
-  return [result, counter.snapshot()];
+  try {
+    const result = await _storage.run(counter, fn);
+    return [result, counter.snapshot()];
+  } catch (err) {
+    attach_graph_cost(err, counter.snapshot());
+    throw err;
+  }
+}
+
+/**
+ * Records `cost` on a thrown value. Non-enumerable, so error logging and
+ * serialisation are unchanged; skipped for primitives and non-extensible
+ * objects, which cannot carry it.
+ */
+function attach_graph_cost(err: unknown, cost: OperationCost): void {
+  if (typeof err !== 'object' || err === null || !Object.isExtensible(err)) return;
+  Object.defineProperty(err, 'graph_cost', {
+    value: cost,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
+}
+
+/**
+ * Graph cost burned before `err` was thrown out of a tracked operation, or
+ * undefined when the error did not come from one. Nested contexts each attach
+ * their own; the value read here is the outermost, i.e. the cost of the call
+ * the caller actually made.
+ */
+export function get_graph_cost(err: unknown): OperationCost | undefined {
+  if (typeof err !== 'object' || err === null || !('graph_cost' in err)) return undefined;
+  const cost = err.graph_cost;
+  return is_operation_cost(cost) ? cost : undefined;
+}
+
+/** Checks that an attached value really is a cost snapshot before handing it out. */
+function is_operation_cost(value: unknown): value is OperationCost {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'requests_total' in value &&
+    typeof value.requests_total === 'number'
+  );
 }
 
 /**

--- a/packages/core/tests/unit/services/shared/graph-cost-on-failure.test.ts
+++ b/packages/core/tests/unit/services/shared/graph-cost-on-failure.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Failures are the most expensive runs a tenant pays for, so the cost burned
+ * before a rejection has to survive it: a scheduler that reads cost only on
+ * success re-queues straight into a tenant that is already throttled.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  run_with_cost_tracking,
+  get_active_counter,
+  get_graph_cost,
+} from '@/services/shared/graph-request-context';
+
+/** Stand-in for a Graph 429: a real error type, so `instanceof` is testable. */
+class ThrottledError extends Error {}
+
+/** Records `count` Graph requests, then fails the way a throttled run does. */
+async function burn_then_fail(
+  count: number,
+  err: unknown = new ThrottledError('429'),
+): Promise<never> {
+  for (let i = 0; i < count; i++) get_active_counter()?.record('outlook', 'delta_sync');
+  throw err;
+}
+
+describe('graph cost on the rejection path', () => {
+  it('reports the requests burned before the failure', async () => {
+    const err = await run_with_cost_tracking(() => burn_then_fail(3)).catch((e: unknown) => e);
+
+    const cost = get_graph_cost(err);
+    expect(cost?.requests_total).toBe(3);
+    expect(cost?.by_service.outlook?.requests).toBe(3);
+    expect(cost?.requests_by_type['delta_sync']).toBe(3);
+  });
+
+  it('rethrows the original error untouched, so instanceof still works', async () => {
+    // Graph errors carry their own fields; the caller's checks must survive.
+    const thrown = Object.assign(new ThrottledError('Too Many Requests'), { statusCode: 429 });
+
+    const caught = await run_with_cost_tracking(() => burn_then_fail(1, thrown)).catch(
+      (e: unknown) => e,
+    );
+
+    expect(caught).toBe(thrown);
+    expect(caught).toBeInstanceOf(ThrottledError);
+    expect(thrown.statusCode).toBe(429);
+    expect(thrown.message).toBe('Too Many Requests');
+  });
+
+  it('keeps the cost off enumerable output so error logging is unchanged', async () => {
+    const err = (await run_with_cost_tracking(() => burn_then_fail(2)).catch(
+      (e: unknown) => e,
+    )) as Error;
+
+    expect(Object.keys(err)).not.toContain('graph_cost');
+    expect(JSON.stringify({ ...err })).not.toContain('requests_total');
+    // Still readable through the accessor.
+    expect(get_graph_cost(err)?.requests_total).toBe(2);
+  });
+
+  it('records a zero-cost snapshot when the operation failed before any request', async () => {
+    const err = await run_with_cost_tracking(async () => {
+      throw new Error('config rejected before any Graph call');
+    }).catch((e: unknown) => e);
+
+    // Zero is a fact worth reporting: it says the failure cost the tenant nothing.
+    expect(get_graph_cost(err)?.requests_total).toBe(0);
+  });
+
+  it('still returns cost through the tuple when the operation succeeds', async () => {
+    const [result, cost] = await run_with_cost_tracking(async () => {
+      get_active_counter()?.record('outlook', 'fetch_message');
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(cost.requests_total).toBe(1);
+  });
+
+  it('reports the outermost call cost when contexts nest', async () => {
+    const err = await run_with_cost_tracking(async () => {
+      get_active_counter()?.record('outlook', 'list_folders');
+      await run_with_cost_tracking(() => burn_then_fail(2));
+    }).catch((e: unknown) => e);
+
+    // The caller ran the outer operation; that is the cost they are billed for.
+    expect(get_graph_cost(err)?.requests_total).toBe(1);
+    expect(get_graph_cost(err)?.requests_by_type['list_folders']).toBe(1);
+  });
+
+  it('survives an error that cannot carry the cost, rather than masking it', async () => {
+    const frozen = Object.freeze(new Error('frozen'));
+
+    const caught = await run_with_cost_tracking(() => burn_then_fail(1, frozen)).catch(
+      (e: unknown) => e,
+    );
+
+    expect(caught).toBe(frozen);
+    expect(get_graph_cost(caught)).toBeUndefined();
+  });
+
+  it('survives a thrown primitive', async () => {
+    const caught = await run_with_cost_tracking(() => burn_then_fail(1, 'boom')).catch(
+      (e: unknown) => e,
+    );
+
+    expect(caught).toBe('boom');
+    expect(get_graph_cost(caught)).toBeUndefined();
+  });
+});
+
+describe('get_graph_cost', () => {
+  it('returns undefined for errors that never went through a tracked operation', () => {
+    expect(get_graph_cost(new Error('unrelated'))).toBeUndefined();
+    expect(get_graph_cost(undefined)).toBeUndefined();
+    expect(get_graph_cost(null)).toBeUndefined();
+    expect(get_graph_cost('string')).toBeUndefined();
+    expect(get_graph_cost(42)).toBeUndefined();
+  });
+
+  it('rejects a graph_cost that is not an OperationCost', () => {
+    expect(
+      get_graph_cost(Object.assign(new Error('x'), { graph_cost: 'not-a-cost' })),
+    ).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,4 +2,5 @@ export * from '@wisecom/atlas-types';
 export type { StorageTargetSdkConfig } from '@wisecom/atlas-s3';
 export { createAtlasInstance } from './atlas-instance.adapter';
 export { create_storage_target as createStorageTarget } from '@wisecom/atlas-s3';
+export { get_graph_cost as getGraphCost } from '@wisecom/atlas-core/services/shared/graph-request-context';
 export { create_container, create_container_from_config } from './container';


### PR DESCRIPTION
Closes #68

## Problem

`run_with_cost_tracking` snapshotted the counter *after* awaiting the operation, with no `try`/`finally`:

```ts
const result = await _storage.run(counter, fn);  // rejects here
return [result, counter.snapshot()];             // never reached
```

On a rejection the counter was garbage-collected with it, so every Graph request made before the failure became invisible. All four SDK entry points are affected — `backup`, `restore`, `restoreMailbox`, `checkMailboxStatus` — since each attaches `graph_cost` only on the success path.

**This is worse than a missing metric.** Failures correlate with *high* cost: a delta sync that dies on page 400, or a call that spent all 12 retry attempts against a 429, has burned more quota than any successful run in the job — and reported zero. The scheduling pattern in `docs/reference/sdk.md` reads `result.graph_cost` to compute a cooldown, so a failed job produced *no* cooldown and pushed the next mailbox straight into an already-throttled tenant, producing another 429. The accounting hole made throttling worse rather than merely unobserved.

## Fix

The cost is attached to the thrown error and read with `getGraphCost`, now exported from the SDK:

```ts
try {
  const result = await atlas.outlook.backup(mailbox_id);
  record_cost(result.graph_cost);
} catch (err) {
  const cost = getGraphCost(err);   // requests burned before it died
  if (cost) record_cost(cost);
  throw err;
}
```

One change in the shared function covers all four entry points — no per-caller patching.

Properties of the fix, each covered by a test:

- **The error is rethrown unchanged** — same object identity, so `instanceof` checks, `statusCode`, and existing catch filters keep working.
- **The cost is non-enumerable**, so error logging, spreading and `JSON.stringify` are unaffected.
- **A failure before any Graph call reports `requests_total: 0`** — a fact worth recording, not a gap.
- **Nested contexts** each attach their own; the caller reads the outermost, i.e. the call they actually made.
- **Errors that cannot carry it** (frozen objects, thrown primitives) propagate untouched rather than being wrapped or masked.

## Verified live through the public SDK

Against the real tenant, `atlas.outlook.backup()` on a mailbox that does not exist — same code path, fix backed out and restored:

| | `graph_cost` on the caught error |
| --- | --- |
| before | `UNDEFINED` — calls burned, nothing reported |
| after | `{"requests_total":1,"by_service":{"identity":{"requests":1,…}},"requests_by_type":{"mailbox_exists":1}}` |

And the production shape from the issue — a real mailbox backup killed 2.4 s in by a storage outage, after the Graph work was already paid for:

```
FAILED after 2448ms
error : connect ECONNREFUSED 127.0.0.1:9002
cost  : 9 Graph requests burned before the failure
        {"mailbox_exists":1,"get_mailbox_purpose":1,"list_folders":1,"delta_sync":6}
        {"identity":{"requests":2,…},"outlook":{"requests":7,…}}
```

That is a 6-page delta sync the tenant paid for and previously saw as nothing. Storage was restarted and a clean backup re-run afterwards; no probes left behind.

## Tests

10 new tests in `packages/core/tests/unit/services/shared/graph-cost-on-failure.test.ts`, including the issue's exact reproduction (record three requests, throw a 429, assert the cost survives). Full suite green (750), lint, format, docs build.

## Docs

`docs/reference/sdk.md` gains a "Cost when an operation fails" section, and the pg-boss example — which previously had no `try`/`catch` at all, so a failed job skipped both the cost row and the cooldown — now bills and cools down on the failure path before rethrowing. `docs/operations/graph-rate-limits.md` matches. `getGraphCost` is listed in the exports.

## Follow-up, not in scope

The decorators record one request per connector method while the adapter may issue many HTTP calls for it (`fetch_delta` records once, then follows `@odata.nextLink` in a loop; `with_graph_retry` can burn 12 attempts per page). That is a systematic undercount on the success path too and is tracked separately in #78.

