### PR TITLE
fix(cost): count Graph requests at the transport, not per connector method

### DIFF
--- a/docs/operations/graph-rate-limits.md
+++ b/docs/operations/graph-rate-limits.md
@@ -253,6 +253,11 @@ Key implications for SaaS scheduling:
 
 ## Using the Limits in Code
 
+`graph_cost` is measured at the transport, so one recorded request is one HTTP
+request: each `@odata.nextLink` page and each retried attempt is counted
+separately. Cooldowns computed from it therefore reflect the quota actually
+consumed rather than the number of connector calls made.
+
 Atlas exports the `GRAPH_SERVICE_LIMITS` constant so your SaaS layer can use the same authoritative numbers for scheduling decisions:
 
 ```typescript

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -261,6 +261,33 @@ console.log(result.graph_cost);
 
 Methods that report `graph_cost`: `atlas.outlook.backup`, `atlas.outlook.restore`, `atlas.outlook.restoreMailbox`, `atlas.outlook.checkMailboxStatus`.
 
+### What counts as a request
+
+One HTTP request to Microsoft Graph is one recorded request. Counting happens in
+the transport, immediately before the request goes out, so the number matches
+what the tenant is actually charged:
+
+- **Every page.** A delta sync that follows `@odata.nextLink` across 40 pages
+  counts 40, not 1. Same for folder trees, drive listings and version history.
+- **Every attempt.** A call throttled twice and succeeding on the third attempt
+  counts 3. Retries made by Atlas and retries made internally by the Graph SDK
+  are both visible here -- and a throttled tenant is exactly when the count
+  matters most.
+- **Every redirect** followed to a new location.
+- **Upload bytes per attempt.** A resumable chunk re-sent after a failure is
+  charged twice against the Outlook 150 MB / 5-minute window, because it was.
+
+`requests_by_type` labels each request with the connector operation that issued
+it, so a paginated `delta_sync` shows the page count under one label.
+
+::: warning Recorded costs are higher than in 2.1.0-beta and earlier
+Earlier releases recorded one request per connector method call, so pagination
+and retries were invisible and reported cost was a floor. Cooldowns derived from
+it were correspondingly too short. Numbers from this release are larger for the
+same work -- that is the undercount being removed, not a change in what Atlas
+does. Expect a step change in any dashboard built on the old values.
+:::
+
 ### Cost when an operation fails
 
 Failures are the most expensive runs a tenant pays for: a delta sync that dies on

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -263,9 +263,9 @@ Methods that report `graph_cost`: `atlas.outlook.backup`, `atlas.outlook.restore
 
 ### What counts as a request
 
-One HTTP request to Microsoft Graph is one recorded request. Counting happens in
-the transport, immediately before the request goes out, so the number matches
-what the tenant is actually charged:
+One request sent through the Graph client is one recorded request. Counting
+happens in the transport, immediately before the request goes out, so the number
+matches what the tenant is actually charged:
 
 - **Every page.** A delta sync that follows `@odata.nextLink` across 40 pages
   counts 40, not 1. Same for folder trees, drive listings and version history.
@@ -276,6 +276,10 @@ what the tenant is actually charged:
 - **Every redirect** followed to a new location.
 - **Upload bytes per attempt.** A resumable chunk re-sent after a failure is
   charged twice against the Outlook 150 MB / 5-minute window, because it was.
+
+Pre-authenticated transfers are deliberately excluded: file downloads from
+`@microsoft.graph.downloadUrl` and OneDrive/SharePoint resumable chunk uploads
+go straight to storage rather than through Graph, and consume no Graph quota.
 
 `requests_by_type` labels each request with the connector operation that issued
 it, so a paginated `delta_sync` shows the page count under one label.

--- a/packages/core/src/services/shared/graph-request-context.ts
+++ b/packages/core/src/services/shared/graph-request-context.ts
@@ -2,18 +2,20 @@
  * AsyncLocalStorage-based context for Graph API request cost tracking.
  *
  * Each SDK method call creates a fresh GraphRequestCounter and runs the
- * underlying operation inside AsyncLocalStorage.run(). Connector decorators
- * call get_active_counter() to record each Graph request without any
- * plumbing through service or use-case layers.
+ * underlying operation inside AsyncLocalStorage.run(). A transport middleware
+ * records one entry per HTTP request actually sent, so pagination and retries
+ * are counted; connector methods declare what they are doing with
+ * run_with_graph_operation() so those requests carry a pool and a label.
  *
  * CLI calls (no counter active) silently produce no cost data.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { GraphRequestCounter } from './graph-request-counter';
-import type { OperationCost } from '@wisecom/atlas-types';
+import type { GraphOperation, OperationCost } from '@wisecom/atlas-types';
 
 const _storage = new AsyncLocalStorage<GraphRequestCounter>();
+const _operation = new AsyncLocalStorage<GraphOperation>();
 
 /**
  * Runs `fn` inside a fresh cost-tracking context and returns both the result
@@ -81,4 +83,25 @@ function is_operation_cost(value: unknown): value is OperationCost {
  */
 export function get_active_counter(): GraphRequestCounter | undefined {
   return _storage.getStore();
+}
+
+/**
+ * Declares what the Graph requests issued inside `fn` are for, so the transport
+ * can charge each one to the right pool under a stable label.
+ *
+ * Scoped rather than recorded: one connector method can issue any number of
+ * requests (continuation pages, retried attempts), and all of them belong to
+ * this operation. Nested scopes shadow, so an inner declaration wins for the
+ * requests it makes.
+ */
+export function run_with_graph_operation<T>(
+  operation: GraphOperation,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return _operation.run(operation, fn);
+}
+
+/** The operation the current async context is inside, if any. */
+export function get_active_operation(): GraphOperation | undefined {
+  return _operation.getStore();
 }

--- a/packages/m365-graph/src/graph-client.factory.ts
+++ b/packages/m365-graph/src/graph-client.factory.ts
@@ -44,14 +44,22 @@ export function create_graph_client(config: GraphConfig): Client {
   });
 }
 
-/** The SDK's default handlers, with cost accounting spliced in above the transport. */
+/**
+ * The SDK's default handlers with cost accounting spliced in.
+ *
+ * Position matters twice over. The cost middleware sits below RetryHandler and
+ * RedirectHandler, both of which re-execute everything beneath them, so it sees
+ * each attempt and each followed redirect rather than one logical call. It sits
+ * above TelemetryHandler because the SDK requires telemetry to be the handler
+ * immediately before the transport, so its usage flags cover the real request.
+ */
 function build_middleware_chain(auth_provider: TokenCredentialAuthenticationProvider): Middleware {
   const chain: Middleware[] = [
     new AuthenticationHandler(auth_provider),
     new RetryHandler(new RetryHandlerOptions()),
     new RedirectHandler(new RedirectHandlerOptions()),
-    new TelemetryHandler(),
     new GraphCostMiddleware(),
+    new TelemetryHandler(),
     new HTTPMessageHandler(),
   ];
 

--- a/packages/m365-graph/src/graph-client.factory.ts
+++ b/packages/m365-graph/src/graph-client.factory.ts
@@ -1,6 +1,17 @@
 import { ClientSecretCredential } from '@azure/identity';
-import { Client } from '@microsoft/microsoft-graph-client';
+import {
+  AuthenticationHandler,
+  Client,
+  HTTPMessageHandler,
+  RedirectHandler,
+  RetryHandler,
+  RetryHandlerOptions,
+  RedirectHandlerOptions,
+  TelemetryHandler,
+  type Middleware,
+} from '@microsoft/microsoft-graph-client';
 import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials/index.js';
+import { GraphCostMiddleware } from '@/graph-cost-middleware';
 import type { GraphConfig } from '@wisecom/atlas-core/utils/config';
 
 export const GRAPH_CLIENT_TOKEN = Symbol.for('GraphClient');
@@ -10,8 +21,14 @@ const GRAPH_BASE_URL = 'https://graph.microsoft.com';
 /**
  * Creates an authenticated Microsoft Graph client using the OAuth2
  * client credentials flow. The SDK handles token acquisition, caching,
- * and automatic refresh. Built-in middleware provides retry on 429/5xx
- * and redirect following.
+ * and automatic refresh.
+ *
+ * The middleware chain is spelled out rather than derived from `authProvider`
+ * so a cost middleware can sit immediately before the HTTP handler, where it
+ * observes every request actually sent -- including each retry the RetryHandler
+ * makes and each redirect the RedirectHandler follows, since both re-execute
+ * the chain below them. It is otherwise the SDK's own default chain, in the
+ * SDK's own order.
  *
  * Hardcodes the base URL to https://graph.microsoft.com to prevent
  * any downstream override to a non-TLS endpoint. Refuses to start
@@ -22,9 +39,26 @@ export function create_graph_client(config: GraphConfig): Client {
   const credential = build_credential(config);
   const auth_provider = build_auth_provider(credential);
   return Client.initWithMiddleware({
-    authProvider: auth_provider,
+    middleware: build_middleware_chain(auth_provider),
     baseUrl: GRAPH_BASE_URL,
   });
+}
+
+/** The SDK's default handlers, with cost accounting spliced in above the transport. */
+function build_middleware_chain(auth_provider: TokenCredentialAuthenticationProvider): Middleware {
+  const chain: Middleware[] = [
+    new AuthenticationHandler(auth_provider),
+    new RetryHandler(new RetryHandlerOptions()),
+    new RedirectHandler(new RedirectHandlerOptions()),
+    new TelemetryHandler(),
+    new GraphCostMiddleware(),
+    new HTTPMessageHandler(),
+  ];
+
+  for (let i = 0; i < chain.length - 1; i++) {
+    chain[i]!.setNext?.(chain[i + 1]!);
+  }
+  return chain[0]!;
 }
 
 /** Fails hard if TLS cert validation has been globally disabled. */

--- a/packages/m365-graph/src/graph-cost-middleware.ts
+++ b/packages/m365-graph/src/graph-cost-middleware.ts
@@ -1,0 +1,92 @@
+/**
+ * Counts Graph API cost where the requests actually happen: the transport.
+ *
+ * Recording at the connector-method boundary counted one request per method,
+ * but a method routinely issues many: a delta sync follows `@odata.nextLink`
+ * until the collection is exhausted, and a throttled call is retried by
+ * `with_graph_retry` (up to 12 attempts) and again by the SDK's own
+ * RetryHandler, which this layer is the only place able to see. Reported cost
+ * was therefore a floor, and consumers computing a throttling cooldown from it
+ * got a number that was always too small -- the unsafe direction.
+ *
+ * Placed immediately before HTTPMessageHandler, this middleware is invoked once
+ * per outgoing HTTP request, including every retry and every followed redirect,
+ * because both of those handlers re-execute the chain downstream of themselves.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/throttling-limits
+ */
+
+import type { Context, Middleware } from '@microsoft/microsoft-graph-client';
+import type { GraphServicePool } from '@wisecom/atlas-types';
+import {
+  get_active_counter,
+  get_active_operation,
+} from '@wisecom/atlas-core/services/shared/graph-request-context';
+
+/** Records one Graph request against the active cost counter, then continues the chain. */
+export class GraphCostMiddleware implements Middleware {
+  private _next?: Middleware;
+
+  async execute(context: Context): Promise<void> {
+    // Recorded before the call: a request that leaves the process has already
+    // been charged against the tenant's quota, whatever the response turns out
+    // to be. Nothing is recorded when no SDK cost context is active (CLI runs).
+    const counter = get_active_counter();
+    if (counter) {
+      const operation = get_active_operation();
+      const url = request_url(context);
+      counter.record(
+        operation?.pool ?? pool_for_url(url),
+        operation?.request_type ?? 'unlabelled',
+        {
+          resource_units: operation?.resource_units ?? 1,
+          upload_bytes: request_body_bytes(context),
+        },
+      );
+    }
+
+    await this._next?.execute(context);
+  }
+
+  setNext(next: Middleware): void {
+    this._next = next;
+  }
+}
+
+/** Reads the target URL from a context whose request may be a string or a Request. */
+function request_url(context: Context): string {
+  return typeof context.request === 'string' ? context.request : context.request.url;
+}
+
+/**
+ * Best-effort pool for a request made outside any declared operation.
+ *
+ * Every Graph call Atlas makes today runs inside a declared operation, so this
+ * is a backstop for future callers rather than a routine path. Unrecognised
+ * paths fall to `identity`: the request is real and must appear in the totals,
+ * and the directory pool is where uncategorised Graph endpoints live.
+ */
+function pool_for_url(url: string): GraphServicePool {
+  const path = url.replace(/^https?:\/\/[^/]+/, '').toLowerCase();
+  if (/\/(drives?|sites|shares)\b/.test(path)) return 'sharepoint_onedrive';
+  if (/\/(messages|mailfolders|mailboxsettings|sendmail|events|calendars?)\b/.test(path)) {
+    return 'outlook';
+  }
+  return 'identity';
+}
+
+/**
+ * Size of the request body in bytes, for the Outlook upload window. Streams and
+ * form data report 0 -- their length is not knowable without consuming them,
+ * and consuming them here would break the request.
+ */
+function request_body_bytes(context: Context): number {
+  const body =
+    typeof context.request === 'string' ? context.options?.body : (context.options?.body ?? null);
+  if (!body) return 0;
+  if (typeof body === 'string') return Buffer.byteLength(body);
+  if (Buffer.isBuffer(body)) return body.length;
+  if (body instanceof ArrayBuffer) return body.byteLength;
+  if (ArrayBuffer.isView(body)) return body.byteLength;
+  return 0;
+}

--- a/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
+++ b/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
@@ -24,7 +24,7 @@ import type {
   MailboxRateLimiterFactory,
 } from '@wisecom/atlas-core/services/shared/mailbox-rate-limiter';
 import type { ThrottleFence } from '@wisecom/atlas-core/services/shared/throttle-fence';
-import { get_active_counter } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import { run_with_graph_operation } from '@wisecom/atlas-core/services/shared/graph-request-context';
 import { GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -46,20 +46,28 @@ export class RateLimitedGraphConnector implements MailboxConnector {
 
   async list_mailboxes(tenant_id: string): Promise<string[]> {
     // GET /users -- Identity pool, not gated by per-mailbox semaphore
-    get_active_counter()?.record('identity', 'list_users', {
-      resource_units: GRAPH_SERVICE_LIMITS.identity.users_list_cost,
-    });
-    return this._inner.list_mailboxes(tenant_id);
+    return run_with_graph_operation(
+      {
+        pool: 'identity',
+        request_type: 'list_users',
+        resource_units: GRAPH_SERVICE_LIMITS.identity.users_list_cost,
+      },
+      () => this._inner.list_mailboxes(tenant_id),
+    );
   }
 
   async mailbox_exists(tenant_id: string, owner_id: string): Promise<boolean> {
     // GET /users/{id} -- Identity pool
-    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () => {
-      get_active_counter()?.record('identity', 'mailbox_exists', {
-        resource_units: GRAPH_SERVICE_LIMITS.identity.user_get_cost,
-      });
-      return this._inner.mailbox_exists(tenant_id, owner_id);
-    });
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () =>
+      run_with_graph_operation(
+        {
+          pool: 'identity',
+          request_type: 'mailbox_exists',
+          resource_units: GRAPH_SERVICE_LIMITS.identity.user_get_cost,
+        },
+        () => this._inner.mailbox_exists(tenant_id, owner_id),
+      ),
+    );
   }
 
   async get_mailbox_purpose(
@@ -68,19 +76,24 @@ export class RateLimitedGraphConnector implements MailboxConnector {
   ): Promise<MailboxPurpose | undefined> {
     if (!this._inner.get_mailbox_purpose) return undefined;
     // GET /users/{id}/mailboxSettings -- Identity pool
-    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () => {
-      get_active_counter()?.record('identity', 'get_mailbox_purpose', {
-        resource_units: GRAPH_SERVICE_LIMITS.identity.user_get_cost,
-      });
-      return this._inner.get_mailbox_purpose!(tenant_id, owner_id);
-    });
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () =>
+      run_with_graph_operation(
+        {
+          pool: 'identity',
+          request_type: 'get_mailbox_purpose',
+          resource_units: GRAPH_SERVICE_LIMITS.identity.user_get_cost,
+        },
+        () => this._inner.get_mailbox_purpose!(tenant_id, owner_id),
+      ),
+    );
   }
 
   async list_mail_folders(tenant_id: string, owner_id: string): Promise<MailFolder[]> {
-    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () => {
-      get_active_counter()?.record('outlook', 'list_folders');
-      return this._inner.list_mail_folders(tenant_id, owner_id);
-    });
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'list_folders' }, () =>
+        this._inner.list_mail_folders(tenant_id, owner_id),
+      ),
+    );
   }
 
   async fetch_delta(
@@ -92,17 +105,18 @@ export class RateLimitedGraphConnector implements MailboxConnector {
     page_size?: number,
   ): Promise<DeltaSyncResult> {
     const cost = prev_delta_link ? DELTA_WITH_TOKEN_COST : DELTA_WITHOUT_TOKEN_COST;
-    return this.rateLimited(owner_id, cost, () => {
-      get_active_counter()?.record('outlook', 'delta_sync');
-      return this._inner.fetch_delta(
-        tenant_id,
-        owner_id,
-        folder_id,
-        prev_delta_link,
-        on_page,
-        page_size,
-      );
-    });
+    return this.rateLimited(owner_id, cost, () =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'delta_sync' }, () =>
+        this._inner.fetch_delta(
+          tenant_id,
+          owner_id,
+          folder_id,
+          prev_delta_link,
+          on_page,
+          page_size,
+        ),
+      ),
+    );
   }
 
   async fetch_message(
@@ -110,10 +124,11 @@ export class RateLimitedGraphConnector implements MailboxConnector {
     owner_id: string,
     message_id: string,
   ): Promise<MailMessage> {
-    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () => {
-      get_active_counter()?.record('outlook', 'fetch_message');
-      return this._inner.fetch_message(tenant_id, owner_id, message_id);
-    });
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'fetch_message' }, () =>
+        this._inner.fetch_message(tenant_id, owner_id, message_id),
+      ),
+    );
   }
 
   async fetch_attachments(
@@ -121,10 +136,11 @@ export class RateLimitedGraphConnector implements MailboxConnector {
     owner_id: string,
     message_id: string,
   ): Promise<MessageAttachment[]> {
-    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () => {
-      get_active_counter()?.record('outlook', 'fetch_attachments');
-      return this._inner.fetch_attachments(tenant_id, owner_id, message_id);
-    });
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'fetch_attachments' }, () =>
+        this._inner.fetch_attachments(tenant_id, owner_id, message_id),
+      ),
+    );
   }
 
   /** Shuts down all per-mailbox limiters. */

--- a/packages/m365-graph/tests/unit/cost-tracking-connectors.test.ts
+++ b/packages/m365-graph/tests/unit/cost-tracking-connectors.test.ts
@@ -1,25 +1,42 @@
+/**
+ * The connector decorator declares what each call is doing; the transport
+ * middleware turns that declaration into one cost record per HTTP request.
+ * These tests cover the declaration half -- that every method runs its inner
+ * call inside an operation scope carrying the right pool, label and RU.
+ *
+ * Asserting a request count here instead would be asserting a fiction: the
+ * stub issues no HTTP request, and the real adapter issues many per call.
+ */
+
 import { describe, it, expect, vi } from 'vitest';
 import type { MailboxConnector } from '@wisecom/atlas-types/ports/mail/connector.port';
+import type { GraphOperation } from '@wisecom/atlas-types';
 import { RateLimitedGraphConnector } from '@/rate-limited-graph-connector.adapter';
 import { ThrottleFence } from '@wisecom/atlas-core/services/shared/throttle-fence';
 import { DefaultMailboxRateLimiterFactory } from '@wisecom/atlas-core/services/shared/mailbox-rate-limiter';
-import { run_with_cost_tracking } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import { get_active_operation } from '@wisecom/atlas-core/services/shared/graph-request-context';
 import { GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-types';
 
-function make_mailbox_stub(): MailboxConnector {
+/** Captures the operation visible to the inner connector, i.e. to the transport. */
+function make_capturing_stub(seen: GraphOperation[]): MailboxConnector {
+  const capture =
+    <T>(value: T) =>
+    async () => {
+      const op = get_active_operation();
+      if (op) seen.push(op);
+      return value;
+    };
   return {
-    list_mailboxes: vi.fn().mockResolvedValue(['mb1']),
-    mailbox_exists: vi.fn().mockResolvedValue(true),
-    list_mail_folders: vi.fn().mockResolvedValue([]),
-    fetch_delta: vi.fn().mockResolvedValue({
-      messages: [],
-      removed_ids: [],
-      delta_link: 'https://example.com/delta?token=abc',
-      delta_reset: false,
-    }),
-    fetch_message: vi.fn().mockResolvedValue({}),
-    fetch_attachments: vi.fn().mockResolvedValue([]),
-  };
+    list_mailboxes: vi.fn(capture(['mb1'])),
+    mailbox_exists: vi.fn(capture(true)),
+    get_mailbox_purpose: vi.fn(capture('user')),
+    list_mail_folders: vi.fn(capture([])),
+    fetch_delta: vi.fn(
+      capture({ messages: [], removed_ids: [], delta_link: 'https://x/delta', delta_reset: false }),
+    ),
+    fetch_message: vi.fn(capture({})),
+    fetch_attachments: vi.fn(capture([])),
+  } as unknown as MailboxConnector;
 }
 
 function make_rate_limited(inner: MailboxConnector): RateLimitedGraphConnector {
@@ -28,63 +45,65 @@ function make_rate_limited(inner: MailboxConnector): RateLimitedGraphConnector {
   return new RateLimitedGraphConnector(inner, factory, fence);
 }
 
-describe('RateLimitedGraphConnector — pool attribution', () => {
-  it('list_mailboxes records to identity pool with correct RU', async () => {
-    const connector = make_rate_limited(make_mailbox_stub());
-    const [, cost] = await run_with_cost_tracking(() => connector.list_mailboxes('tenant'));
+describe('RateLimitedGraphConnector — operation labelling', () => {
+  it('labels list_mailboxes as an identity call carrying the list RU cost', async () => {
+    const seen: GraphOperation[] = [];
+    await make_rate_limited(make_capturing_stub(seen)).list_mailboxes('tenant');
 
-    expect(cost.by_service.identity?.requests).toBe(1);
-    expect(cost.by_service.identity?.resource_units).toBe(
-      GRAPH_SERVICE_LIMITS.identity.users_list_cost,
-    );
-    expect(cost.requests_by_type['list_users']).toBe(1);
-    expect(cost.by_service.outlook).toBeUndefined();
+    expect(seen).toEqual([
+      {
+        pool: 'identity',
+        request_type: 'list_users',
+        resource_units: GRAPH_SERVICE_LIMITS.identity.users_list_cost,
+      },
+    ]);
   });
 
-  it('mailbox_exists records to identity pool', async () => {
-    const connector = make_rate_limited(make_mailbox_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.mailbox_exists('tenant', 'user@example.com'),
-    );
+  it('labels mailbox_exists as an identity call carrying the get RU cost', async () => {
+    const seen: GraphOperation[] = [];
+    await make_rate_limited(make_capturing_stub(seen)).mailbox_exists('tenant', 'user@example.com');
 
-    expect(cost.by_service.identity?.requests).toBe(1);
-    expect(cost.requests_by_type['mailbox_exists']).toBe(1);
-    expect(cost.by_service.outlook).toBeUndefined();
+    expect(seen[0]?.pool).toBe('identity');
+    expect(seen[0]?.request_type).toBe('mailbox_exists');
+    expect(seen[0]?.resource_units).toBe(GRAPH_SERVICE_LIMITS.identity.user_get_cost);
   });
 
-  it('list_mail_folders records to outlook pool', async () => {
-    const connector = make_rate_limited(make_mailbox_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.list_mail_folders('tenant', 'user@example.com'),
+  it('labels get_mailbox_purpose as an identity call', async () => {
+    const seen: GraphOperation[] = [];
+    await make_rate_limited(make_capturing_stub(seen)).get_mailbox_purpose!(
+      'tenant',
+      'user@example.com',
     );
 
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.requests_by_type['list_folders']).toBe(1);
-    expect(cost.by_service.identity).toBeUndefined();
+    expect(seen[0]?.pool).toBe('identity');
+    expect(seen[0]?.request_type).toBe('get_mailbox_purpose');
   });
 
-  it('fetch_delta records to outlook pool', async () => {
-    const connector = make_rate_limited(make_mailbox_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.fetch_delta('tenant', 'user@example.com', 'folder-id'),
+  it.each([
+    ['list_mail_folders', 'list_folders'],
+    ['fetch_delta', 'delta_sync'],
+    ['fetch_message', 'fetch_message'],
+    ['fetch_attachments', 'fetch_attachments'],
+  ])('labels %s as an outlook call typed %s', async (method, expected_type) => {
+    const seen: GraphOperation[] = [];
+    const connector = make_rate_limited(make_capturing_stub(seen));
+
+    await (connector[method as 'fetch_message'] as (...a: string[]) => Promise<unknown>)(
+      'tenant',
+      'user@example.com',
+      'id',
     );
 
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.requests_by_type['delta_sync']).toBe(1);
+    expect(seen[0]?.pool).toBe('outlook');
+    expect(seen[0]?.request_type).toBe(expected_type);
+    // Outlook is a flat-cost pool: RU per request equals 1, the default.
+    expect(seen[0]?.resource_units).toBeUndefined();
   });
 
-  it('fetch_attachments records to outlook pool', async () => {
-    const connector = make_rate_limited(make_mailbox_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.fetch_attachments('tenant', 'user@example.com', 'msg-id'),
-    );
+  it('leaves no operation in scope once the call returns', async () => {
+    const seen: GraphOperation[] = [];
+    await make_rate_limited(make_capturing_stub(seen)).list_mailboxes('tenant');
 
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.requests_by_type['fetch_attachments']).toBe(1);
-  });
-
-  it('does not throw when called outside a tracking context', async () => {
-    const connector = make_rate_limited(make_mailbox_stub());
-    await expect(connector.list_mail_folders('tenant', 'user@example.com')).resolves.toBeDefined();
+    expect(get_active_operation()).toBeUndefined();
   });
 });

--- a/packages/m365-graph/tests/unit/graph-cost-middleware.test.ts
+++ b/packages/m365-graph/tests/unit/graph-cost-middleware.test.ts
@@ -1,0 +1,200 @@
+/**
+ * The counting half of cost tracking. The middleware sits immediately before
+ * the SDK's HTTP handler, so it is invoked once per request actually sent --
+ * which is what makes paginated and retried calls count for what they cost.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Context, Middleware } from '@microsoft/microsoft-graph-client';
+import { GraphCostMiddleware } from '@/graph-cost-middleware';
+import {
+  get_graph_cost,
+  run_with_cost_tracking,
+  run_with_graph_operation,
+} from '@wisecom/atlas-core/services/shared/graph-request-context';
+
+/** Terminal handler standing in for HTTPMessageHandler. */
+function make_transport(): Middleware & { calls: number } {
+  return {
+    calls: 0,
+    async execute(this: { calls: number }) {
+      this.calls++;
+    },
+  } as Middleware & { calls: number };
+}
+
+function make_chain(): {
+  middleware: GraphCostMiddleware;
+  transport: Middleware & { calls: number };
+} {
+  const middleware = new GraphCostMiddleware();
+  const transport = make_transport();
+  middleware.setNext(transport);
+  return { middleware, transport };
+}
+
+function context_for(url: string, options?: Context['options']): Context {
+  return { request: url, options } as Context;
+}
+
+const DELTA_URL = 'https://graph.microsoft.com/v1.0/users/u/mailFolders/f/messages/delta';
+
+describe('GraphCostMiddleware', () => {
+  it('counts every request of a paginated call, not the call', async () => {
+    const { middleware } = make_chain();
+
+    const [, cost] = await run_with_cost_tracking(() =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'delta_sync' }, async () => {
+        // One connector call, four continuation pages.
+        for (let page = 0; page < 4; page++) await middleware.execute(context_for(DELTA_URL));
+      }),
+    );
+
+    expect(cost.requests_total).toBe(4);
+    expect(cost.requests_by_type['delta_sync']).toBe(4);
+    expect(cost.by_service.outlook?.requests).toBe(4);
+  });
+
+  it('counts every retried attempt of a single request', async () => {
+    const { middleware } = make_chain();
+
+    const [, cost] = await run_with_cost_tracking(() =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'fetch_message' }, async () => {
+        // A throttled request re-executes the chain below the retry handler.
+        for (let attempt = 0; attempt < 3; attempt++) {
+          await middleware.execute(
+            context_for('https://graph.microsoft.com/v1.0/users/u/messages/1'),
+          );
+        }
+      }),
+    );
+
+    expect(cost.requests_total).toBe(3);
+    expect(cost.by_service.outlook?.requests).toBe(3);
+  });
+
+  it('charges the declared resource units per request, not per call', async () => {
+    const { middleware } = make_chain();
+
+    const [, cost] = await run_with_cost_tracking(() =>
+      run_with_graph_operation(
+        { pool: 'identity', request_type: 'list_users', resource_units: 2 },
+        async () => {
+          await middleware.execute(context_for('https://graph.microsoft.com/v1.0/users'));
+          await middleware.execute(context_for('https://graph.microsoft.com/v1.0/users?$skip=1'));
+        },
+      ),
+    );
+
+    expect(cost.by_service.identity?.requests).toBe(2);
+    expect(cost.by_service.identity?.resource_units).toBe(4);
+  });
+
+  it('measures upload bytes from the request body', async () => {
+    const { middleware } = make_chain();
+    const chunk = Buffer.alloc(1024);
+
+    const [, cost] = await run_with_cost_tracking(() =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'upload_chunk' }, async () => {
+        // A retried chunk is sent twice and charged twice against the window.
+        await middleware.execute(
+          context_for('https://graph.microsoft.com/upload', { body: chunk }),
+        );
+        await middleware.execute(
+          context_for('https://graph.microsoft.com/upload', { body: chunk }),
+        );
+      }),
+    );
+
+    expect(cost.by_service.outlook?.upload_bytes).toBe(2048);
+  });
+
+  it('counts a string body by its encoded length', async () => {
+    const { middleware } = make_chain();
+
+    const [, cost] = await run_with_cost_tracking(() =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'create_message' }, () =>
+        middleware.execute(
+          context_for('https://graph.microsoft.com/v1.0/users/u/messages', {
+            body: '{"subject":"hyvää"}',
+          }),
+        ),
+      ),
+    );
+
+    expect(cost.by_service.outlook?.upload_bytes).toBe(Buffer.byteLength('{"subject":"hyvää"}'));
+  });
+
+  it('always continues the chain, counter or not', async () => {
+    const { middleware, transport } = make_chain();
+
+    await run_with_cost_tracking(() => middleware.execute(context_for(DELTA_URL)));
+    await middleware.execute(context_for(DELTA_URL)); // no cost context (CLI run)
+
+    expect(transport.calls).toBe(2);
+  });
+
+  it('records nothing outside an SDK cost context', async () => {
+    const { middleware } = make_chain();
+    // A CLI run has no counter; the middleware must stay silent, not throw.
+    await expect(middleware.execute(context_for(DELTA_URL))).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['https://graph.microsoft.com/v1.0/users/u/mailFolders', 'outlook'],
+    ['https://graph.microsoft.com/v1.0/users/u/messages/1/attachments', 'outlook'],
+    ['https://graph.microsoft.com/v1.0/users/u/mailboxSettings', 'outlook'],
+    ['https://graph.microsoft.com/v1.0/sites/s/drives', 'sharepoint_onedrive'],
+    ['https://graph.microsoft.com/v1.0/drives/d/root/delta', 'sharepoint_onedrive'],
+    ['https://graph.microsoft.com/v1.0/users/u/drive/root/delta', 'sharepoint_onedrive'],
+    ['https://graph.microsoft.com/v1.0/users', 'identity'],
+  ])('attributes an unlabelled %s to the %s pool', async (url, pool) => {
+    const { middleware } = make_chain();
+
+    const [, cost] = await run_with_cost_tracking(() => middleware.execute(context_for(url)));
+
+    expect(cost.by_service[pool as 'outlook']?.requests).toBe(1);
+    expect(cost.requests_by_type['unlabelled']).toBe(1);
+  });
+
+  it('reads the url from a Request object as well as a string', async () => {
+    const { middleware } = make_chain();
+    const request = { url: 'https://graph.microsoft.com/v1.0/sites/s/drives' } as Request;
+
+    const [, cost] = await run_with_cost_tracking(() => middleware.execute({ request } as Context));
+
+    expect(cost.by_service.sharepoint_onedrive?.requests).toBe(1);
+  });
+
+  it('lets an inner operation label its own requests', async () => {
+    const { middleware } = make_chain();
+
+    const [, cost] = await run_with_cost_tracking(() =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'outer' }, async () => {
+        await middleware.execute(context_for(DELTA_URL));
+        await run_with_graph_operation({ pool: 'outlook', request_type: 'inner' }, () =>
+          middleware.execute(context_for(DELTA_URL)),
+        );
+        await middleware.execute(context_for(DELTA_URL));
+      }),
+    );
+
+    expect(cost.requests_by_type).toEqual({ outer: 2, inner: 1 });
+  });
+
+  it('counts a request that fails downstream: the tenant was still charged', async () => {
+    const middleware = new GraphCostMiddleware();
+    middleware.setNext({
+      execute: vi.fn().mockRejectedValue(new Error('429 Too Many Requests')),
+    } as unknown as Middleware);
+
+    const err = await run_with_cost_tracking(() =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'delta_sync' }, () =>
+        middleware.execute(context_for(DELTA_URL)),
+      ),
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(get_graph_cost(err)?.requests_total).toBe(1);
+  });
+});

--- a/packages/outlook/src/adapters/cost-tracking-restore-connector.adapter.ts
+++ b/packages/outlook/src/adapters/cost-tracking-restore-connector.adapter.ts
@@ -1,17 +1,19 @@
 /**
- * Decorator around RestoreConnector that records every Graph API request to
- * the active GraphRequestCounter (if any).
+ * Decorator around RestoreConnector that labels every Graph request a restore
+ * makes, so the transport-level cost counter can charge it correctly.
  *
  * All restore operations target the Outlook service pool (Exchange Online mail,
- * folder, and attachment endpoints). upload_bytes is populated for attachment
- * uploads to track against the Outlook 150 MB / 5-minute upload window.
+ * folder, and attachment endpoints). Upload bytes are measured at the transport
+ * from the request body rather than declared here: a resumable chunk that is
+ * retried is sent twice, and the tenant's 150 MB / 5-minute upload window is
+ * charged twice for it.
  *
  * @see https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits
  */
 
 import type { RestoreConnector, AttachmentUpload, UploadSession } from '@wisecom/atlas-types';
 import type { MailFolder } from '@wisecom/atlas-types';
-import { get_active_counter } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import { run_with_graph_operation } from '@wisecom/atlas-core/services/shared/graph-request-context';
 
 export class CostTrackingRestoreConnector implements RestoreConnector {
   private readonly _inner: RestoreConnector;
@@ -26,8 +28,9 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     display_name: string,
     parent_folder_id?: string,
   ): Promise<MailFolder> {
-    get_active_counter()?.record('outlook', 'create_folder');
-    return this._inner.create_mail_folder(tenant_id, owner_id, display_name, parent_folder_id);
+    return run_with_graph_operation({ pool: 'outlook', request_type: 'create_folder' }, () =>
+      this._inner.create_mail_folder(tenant_id, owner_id, display_name, parent_folder_id),
+    );
   }
 
   async create_message(
@@ -36,8 +39,9 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     folder_id: string,
     message_body: Record<string, unknown>,
   ): Promise<string> {
-    get_active_counter()?.record('outlook', 'create_message');
-    return this._inner.create_message(tenant_id, owner_id, folder_id, message_body);
+    return run_with_graph_operation({ pool: 'outlook', request_type: 'create_message' }, () =>
+      this._inner.create_message(tenant_id, owner_id, folder_id, message_body),
+    );
   }
 
   async add_attachment(
@@ -46,10 +50,9 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     message_id: string,
     attachment: AttachmentUpload,
   ): Promise<void> {
-    get_active_counter()?.record('outlook', 'add_attachment', {
-      upload_bytes: attachment.content.length,
-    });
-    return this._inner.add_attachment(tenant_id, owner_id, message_id, attachment);
+    return run_with_graph_operation({ pool: 'outlook', request_type: 'add_attachment' }, () =>
+      this._inner.add_attachment(tenant_id, owner_id, message_id, attachment),
+    );
   }
 
   async create_upload_session(
@@ -59,8 +62,11 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     file_name: string,
     file_size: number,
   ): Promise<UploadSession> {
-    get_active_counter()?.record('outlook', 'create_upload_session');
-    return this._inner.create_upload_session(tenant_id, owner_id, message_id, file_name, file_size);
+    return run_with_graph_operation(
+      { pool: 'outlook', request_type: 'create_upload_session' },
+      () =>
+        this._inner.create_upload_session(tenant_id, owner_id, message_id, file_name, file_size),
+    );
   }
 
   async upload_attachment_chunk(
@@ -69,10 +75,9 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     range_start: number,
     total_size: number,
   ): Promise<void> {
-    get_active_counter()?.record('outlook', 'upload_chunk', {
-      upload_bytes: chunk.length,
-    });
-    return this._inner.upload_attachment_chunk(upload_url, chunk, range_start, total_size);
+    return run_with_graph_operation({ pool: 'outlook', request_type: 'upload_chunk' }, () =>
+      this._inner.upload_attachment_chunk(upload_url, chunk, range_start, total_size),
+    );
   }
 
   async count_folder_messages(
@@ -80,8 +85,10 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     owner_id: string,
     folder_id: string,
   ): Promise<number> {
-    get_active_counter()?.record('outlook', 'count_folder_messages');
-    return this._inner.count_folder_messages(tenant_id, owner_id, folder_id);
+    return run_with_graph_operation(
+      { pool: 'outlook', request_type: 'count_folder_messages' },
+      () => this._inner.count_folder_messages(tenant_id, owner_id, folder_id),
+    );
   }
 
   async list_folder_messages(
@@ -90,7 +97,8 @@ export class CostTrackingRestoreConnector implements RestoreConnector {
     folder_id: string,
     top: number,
   ): Promise<Array<{ subject: string; is_draft: boolean }>> {
-    get_active_counter()?.record('outlook', 'list_folder_messages');
-    return this._inner.list_folder_messages(tenant_id, owner_id, folder_id, top);
+    return run_with_graph_operation({ pool: 'outlook', request_type: 'list_folder_messages' }, () =>
+      this._inner.list_folder_messages(tenant_id, owner_id, folder_id, top),
+    );
   }
 }

--- a/packages/outlook/tests/unit/cost-tracking-restore-connector.test.ts
+++ b/packages/outlook/tests/unit/cost-tracking-restore-connector.test.ts
@@ -1,109 +1,80 @@
+/**
+ * The restore decorator declares an operation per call; the transport
+ * middleware records one entry per HTTP request made inside it. These tests
+ * cover the declaration: pool and label reaching the inner connector, which is
+ * where the Graph client -- and therefore the counting middleware -- runs.
+ */
+
 import { describe, it, expect, vi } from 'vitest';
 import type { RestoreConnector } from '@wisecom/atlas-types';
+import type { GraphOperation } from '@wisecom/atlas-types';
 import { CostTrackingRestoreConnector } from '@/adapters/cost-tracking-restore-connector.adapter';
-import { run_with_cost_tracking } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import { get_active_operation } from '@wisecom/atlas-core/services/shared/graph-request-context';
 
-function make_restore_stub(): RestoreConnector {
+function make_capturing_stub(seen: GraphOperation[]): RestoreConnector {
+  const capture =
+    <T>(value: T) =>
+    async () => {
+      const op = get_active_operation();
+      if (op) seen.push(op);
+      return value;
+    };
   return {
-    create_mail_folder: vi.fn().mockResolvedValue({
-      folder_id: 'f1',
-      display_name: 'Test',
-      folder_path: 'Test',
-      total_item_count: 0,
-    }),
-    create_message: vi.fn().mockResolvedValue('msg-id'),
-    add_attachment: vi.fn().mockResolvedValue(undefined),
-    create_upload_session: vi.fn().mockResolvedValue({
-      upload_url: 'https://upload.example.com',
-      expiration: '',
-    }),
-    upload_attachment_chunk: vi.fn().mockResolvedValue(undefined),
-    count_folder_messages: vi.fn().mockResolvedValue(0),
-    list_folder_messages: vi.fn().mockResolvedValue([]),
-  };
+    create_mail_folder: vi.fn(capture({ id: 'folder-id', display_name: 'Restored' })),
+    create_message: vi.fn(capture('msg-id')),
+    add_attachment: vi.fn(capture(undefined)),
+    create_upload_session: vi.fn(capture({ upload_url: 'https://upload', expires_at: '' })),
+    upload_attachment_chunk: vi.fn(capture(undefined)),
+    count_folder_messages: vi.fn(capture(0)),
+    list_folder_messages: vi.fn(capture([])),
+  } as unknown as RestoreConnector;
 }
 
-describe('CostTrackingRestoreConnector', () => {
-  it('create_mail_folder records to outlook pool', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.create_mail_folder('tenant', 'user@example.com', 'Restore-2026'),
-    );
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.requests_by_type['create_folder']).toBe(1);
-    expect(cost.by_service.identity).toBeUndefined();
-  });
+describe('CostTrackingRestoreConnector — operation labelling', () => {
+  it('labels every restore call against the outlook pool', async () => {
+    const seen: GraphOperation[] = [];
+    const connector = new CostTrackingRestoreConnector(make_capturing_stub(seen));
 
-  it('create_message records to outlook pool', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.create_message('tenant', 'user@example.com', 'folder-id', {}),
-    );
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.requests_by_type['create_message']).toBe(1);
-  });
-
-  it('add_attachment records upload_bytes', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.add_attachment('tenant', 'user@example.com', 'msg-id', {
-        name: 'report.pdf',
-        content_type: 'application/pdf',
-        content: Buffer.alloc(2048),
-        is_inline: false,
-        content_id: '',
-      }),
-    );
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.by_service.outlook?.upload_bytes).toBe(2048);
-    expect(cost.requests_by_type['add_attachment']).toBe(1);
-  });
-
-  it('create_upload_session records to outlook pool', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.create_upload_session(
-        'tenant',
-        'user@example.com',
-        'msg-id',
-        'file.zip',
-        10_000_000,
-      ),
-    );
-    expect(cost.by_service.outlook?.requests).toBe(1);
-    expect(cost.requests_by_type['create_upload_session']).toBe(1);
-  });
-
-  it('upload_attachment_chunk records upload_bytes', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    const chunk = Buffer.alloc(4 * 1024 * 1024);
-    const [, cost] = await run_with_cost_tracking(() =>
-      connector.upload_attachment_chunk('https://upload-url', chunk, 0, chunk.length),
-    );
-    expect(cost.by_service.outlook?.upload_bytes).toBe(4 * 1024 * 1024);
-    expect(cost.requests_by_type['upload_chunk']).toBe(1);
-  });
-
-  it('accumulates all restore operations correctly', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    const [, cost] = await run_with_cost_tracking(async () => {
-      await connector.create_mail_folder('tenant', 'user@example.com', 'Restored');
-      await connector.create_message('tenant', 'user@example.com', 'f1', {});
-      await connector.create_message('tenant', 'user@example.com', 'f1', {});
-      await connector.count_folder_messages('tenant', 'user@example.com', 'f1');
+    await connector.create_mail_folder('t', 'user@example.com', 'Restored');
+    await connector.create_message('t', 'user@example.com', 'f1', {});
+    await connector.add_attachment('t', 'user@example.com', 'm1', {
+      name: 'report.pdf',
+      content_type: 'application/pdf',
+      content: Buffer.alloc(8),
     });
+    await connector.create_upload_session('t', 'user@example.com', 'm1', 'big.zip', 1024);
+    await connector.upload_attachment_chunk('https://upload', Buffer.alloc(4), 0, 4);
+    await connector.count_folder_messages('t', 'user@example.com', 'f1');
+    await connector.list_folder_messages('t', 'user@example.com', 'f1', 10);
 
-    expect(cost.requests_total).toBe(4);
-    expect(cost.by_service.outlook?.requests).toBe(4);
-    expect(cost.requests_by_type['create_folder']).toBe(1);
-    expect(cost.requests_by_type['create_message']).toBe(2);
-    expect(cost.requests_by_type['count_folder_messages']).toBe(1);
+    expect(seen.map((op) => op.request_type)).toEqual([
+      'create_folder',
+      'create_message',
+      'add_attachment',
+      'create_upload_session',
+      'upload_chunk',
+      'count_folder_messages',
+      'list_folder_messages',
+    ]);
+    expect(seen.every((op) => op.pool === 'outlook')).toBe(true);
   });
 
-  it('does not throw outside a tracking context', async () => {
-    const connector = new CostTrackingRestoreConnector(make_restore_stub());
-    await expect(
-      connector.create_mail_folder('tenant', 'user@example.com', 'Test'),
-    ).resolves.toBeDefined();
+  it('leaves upload byte accounting to the transport', async () => {
+    const seen: GraphOperation[] = [];
+    const connector = new CostTrackingRestoreConnector(make_capturing_stub(seen));
+
+    await connector.upload_attachment_chunk('https://upload', Buffer.alloc(4 * 1024 * 1024), 0, 4);
+
+    // Declaring the size here would count a retried chunk once, though the
+    // window is charged for every attempt actually sent.
+    expect(seen[0]).toEqual({ pool: 'outlook', request_type: 'upload_chunk' });
+  });
+
+  it('leaves no operation in scope once a call returns', async () => {
+    const connector = new CostTrackingRestoreConnector(make_capturing_stub([]));
+
+    await connector.create_message('t', 'user@example.com', 'f1', {});
+
+    expect(get_active_operation()).toBeUndefined();
   });
 });

--- a/packages/types/src/domain/graph-cost.ts
+++ b/packages/types/src/domain/graph-cost.ts
@@ -55,3 +55,21 @@ export interface OperationCost {
   /** Wall-clock duration of the SDK operation in milliseconds. */
   readonly elapsed_ms: number;
 }
+
+/**
+ * What a connector is doing, declared around a call so every HTTP request the
+ * call issues -- first page, continuation pages, and retried attempts -- can be
+ * charged to the right pool under a stable label.
+ *
+ * Connector methods declare intent; the transport counts reality. Recording at
+ * the method boundary instead would count one request per method and miss both
+ * pagination and retries.
+ */
+export interface GraphOperation {
+  /** Throttling pool the requests are charged against. */
+  readonly pool: GraphServicePool;
+  /** Stable label reported in `requests_by_type`, e.g. `delta_sync`. */
+  readonly request_type: string;
+  /** Resource units per request. Defaults to 1, correct for the flat Outlook model. */
+  readonly resource_units?: number;
+}

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -51,7 +51,12 @@ export type {
   SharePointFileVersionIndex,
   SharePointDeltaCursor,
 } from './sharepoint-manifest';
-export type { OperationCost, ServicePoolCost, GraphServicePool } from './graph-cost';
+export type {
+  GraphOperation,
+  OperationCost,
+  ServicePoolCost,
+  GraphServicePool,
+} from './graph-cost';
 export type {
   GraphServiceLimits,
   OutlookServiceLimits,


### PR DESCRIPTION
Closes #78

## Problem

`graph_cost` recorded once per connector *method*, but a method issues as many HTTP requests as the work needs. `fetch_delta` recorded one, then followed `@odata.nextLink` until the collection ended. Any call could be retried up to 12 times by `with_graph_retry` — and again by the Graph SDK's own `RetryHandler`, which `with_graph_retry` never sees at all.

Reported cost was a floor, so the cooldown consumers compute from it was too short. The error was always in the unsafe direction: schedule the next job too early, into a tenant with less headroom than the number claims.

Measured on the live tenant before the fix, one full mailbox backup: **reported 10, actually 15 HTTP requests — a 1.50× undercount, with no throttling and barely any pagination.** A large mailbox against a throttled tenant is far worse, because retries multiply exactly when the number matters most.

## Fix

Counting moves to a middleware placed immediately before `HTTPMessageHandler`. Both `RetryHandler` and `RedirectHandler` re-execute the chain *below* them ([source](https://github.com/microsoftgraph/msgraph-sdk-javascript/blob/dev/src/middleware/RetryHandler.ts)), so that position is invoked once per request actually sent — attempts and redirects included. It is the only layer that can see them all; incrementing inside `with_graph_retry` and each pagination loop, the other option on the issue, cannot see the SDK's internal retries and drifts as loops are added.

Connector decorators keep their knowledge of intent but stop counting. They declare an operation around the call:

```ts
return run_with_graph_operation({ pool: 'outlook', request_type: 'delta_sync' }, () =>
  this._inner.fetch_delta(...),
);
```

and the transport charges every request that call makes to it. Connector says *what*, transport says *how many* — so labels stay meaningful while counts become true. Upload bytes now come from the actual request body, so a resumable chunk re-sent after a failure is charged twice against the Outlook 150 MB window, because it was.

The client factory spells out the SDK's default chain rather than deriving it from `authProvider` (the two are mutually exclusive). Same handlers, same order, counter spliced in above the transport.

## Verified live

Same probe, same mailbox, counting real HTTP calls at `fetch`:

| | reported | actual | factor |
| --- | --- | --- | --- |
| before | 10 | 15 | **1.50×** |
| after | **15** | 15 | **1.00×** |

The labels became truthful too: `delta_sync` 6 → 10 (six pages on one folder plus four on another), `list_folders` 1 → 2 (the folder root plus the child-folder walk added by #47).

Because this replaces the default middleware chain, all three workloads were re-run end to end against the live tenant: **Outlook** backup via the SDK (15/15 above), **SharePoint** `--full` (25 changed, HEALTHY — exercises streamed downloads and CDN redirects), **OneDrive** backup (3 stored, version history, HEALTHY), and tenant mailbox discovery. Auth, retry, redirect and telemetry all still behave.

Retry counting is covered by unit test rather than live, since a healthy tenant will not produce a 429 on demand; the middleware's placement is verified against the SDK's own source.

## Tests

The two cost-tracking connector test files asserted that one method call records one request — the very thing that was wrong. They would have passed with 400 pages counted as 1. They now cover operation labelling, and the counting contract is tested directly against the middleware: pagination (4 pages → 4), retries (3 attempts → 3), RU charged per request, per-attempt upload bytes, nested operation scopes, pool attribution by URL, chain continuation with and without a cost context, and a request that fails downstream still being counted.

Full suite green (779), lint, format, docs build.

## Docs

`docs/reference/sdk.md` gains a "What counts as a request" section, plus a warning that recorded costs step up compared with earlier releases — that is the undercount being removed, not a behaviour change, and anyone with a dashboard on the old numbers should expect the jump. `docs/operations/graph-rate-limits.md` matches.

## Not in scope

OneDrive and SharePoint still record no cost at all: their SDK entry points never open a cost context, and their connectors declare no operations. The middleware will count their requests the moment either is wired (falling back to URL-derived pool attribution and an `unlabelled` type), but giving those workloads a `graph_cost` field is a feature with its own result-type and docs changes, not part of this fix.
