### PR TITLE
fix(deletion): erase versions, and purge the whole tenant bucket

### DIFF
--- a/docs/azure-ad-setup.md
+++ b/docs/azure-ad-setup.md
@@ -6,11 +6,11 @@ Atlas authenticates with Microsoft Graph using the **OAuth2 Client Credentials f
 
 In the Azure Portal, register an application with the following **Application** permissions (not Delegated):
 
-| Permission             | Why                                                     | Required For                     |
-| ---------------------- | ------------------------------------------------------- | -------------------------------- |
-| `Mail.Read`            | Read mailbox contents via Graph API                     | Backup, list, read, save, verify |
-| `Mail.ReadWrite`       | Restore messages and create folders in target mailboxes | Restore only                     |
-| `User.Read.All`        | Enumerate users and resolve mailbox IDs                 | User discovery                   |
+| Permission             | Why                                                                                  | Required For                          |
+| ---------------------- | ------------------------------------------------------------------------------------ | ------------------------------------- |
+| `Mail.Read`            | Read mailbox contents via Graph API                                                  | Backup, list, read, save, verify      |
+| `Mail.ReadWrite`       | Restore messages and create folders in target mailboxes                              | Restore only                          |
+| `User.Read.All`        | Enumerate users and resolve mailbox IDs                                              | User discovery                        |
 | `MailboxSettings.Read` | Read mailbox metadata and folder structure; shared-mailbox detection (`userPurpose`) | Folder enumeration, mailbox discovery |
 
 ### Principle of Least Privilege

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,12 +6,12 @@ A mental model for how Atlas works before diving into CLI flags and configuratio
 
 Atlas is published as two npm packages that share the same engine but target different integration styles:
 
-| | `@wisecom/atlas-cli` | `@wisecom/atlas-sdk` |
-| --- | --- | --- |
-| **Install** | `npm install -g @wisecom/atlas-cli` | `npm add @wisecom/atlas-sdk` |
+|               | `@wisecom/atlas-cli`                          | `@wisecom/atlas-sdk`                                      |
+| ------------- | --------------------------------------------- | --------------------------------------------------------- |
+| **Install**   | `npm install -g @wisecom/atlas-cli`           | `npm add @wisecom/atlas-sdk`                              |
 | **Interface** | Shell commands (`atlas outlook backup`, etc.) | Typed TypeScript methods (`atlas.outlook.backup()`, etc.) |
-| **Config** | `.env` file and environment variables | Explicit object passed to `createAtlasInstance()` |
-| **Best for** | Cron jobs, systemd timers, operator workflows | Custom apps, multi-tenant SaaS, portals, automation |
+| **Config**    | `.env` file and environment variables         | Explicit object passed to `createAtlasInstance()`         |
+| **Best for**  | Cron jobs, systemd timers, operator workflows | Custom apps, multi-tenant SaaS, portals, automation       |
 
 Both packages support Outlook, OneDrive, and SharePoint workloads. The CLI is optimized for simple deployment; the SDK is for building on top of Atlas programmatically.
 
@@ -19,11 +19,11 @@ Both packages support Outlook, OneDrive, and SharePoint workloads. The CLI is op
 
 Atlas protects three Microsoft 365 workloads, each with its own CLI namespace and storage prefix within the tenant bucket:
 
-| Workload | CLI namespace | Target | Storage prefix |
-| -------- | ------------- | ------ | -------------- |
-| **Outlook** | `atlas outlook` | Mailbox (email address or Graph ID) | `outlook/` |
-| **OneDrive** | `atlas onedrive` | User (email/UPN or Entra object ID) | `onedrive/` |
-| **SharePoint** | `atlas sharepoint` | Site (URL or Graph site ID) | `sharepoint/` |
+| Workload       | CLI namespace      | Target                              | Storage prefix |
+| -------------- | ------------------ | ----------------------------------- | -------------- |
+| **Outlook**    | `atlas outlook`    | Mailbox (email address or Graph ID) | `outlook/`     |
+| **OneDrive**   | `atlas onedrive`   | User (email/UPN or Entra object ID) | `onedrive/`    |
+| **SharePoint** | `atlas sharepoint` | Site (URL or Graph site ID)         | `sharepoint/`  |
 
 All workloads share the same per-tenant encryption key (DEK) and S3 bucket. Cross-cutting commands like `atlas replicate`, `atlas rehydrate`, and `atlas stats` operate across workloads within a tenant.
 
@@ -58,17 +58,17 @@ This also explains why snapshot-level delete only removes the manifest, not the 
 
 ## Key Terms Glossary
 
-| Term | Definition |
-| ---- | ---------- |
-| **DEK** (Data Encryption Key) | A 256-bit symmetric key generated once per tenant and stored as a versioned, self-describing blob at `_meta/dek.enc`. The blob header records the KDF parameters; the DEK itself is AES-256-GCM encrypted with a KEK. All message, attachment, and file ciphertext in the bucket is encrypted with the DEK. |
-| **KEK** (Key Encryption Key) | A key derived from the master passphrase using scrypt (N=65536, r=8, p=1) with a per-wrap random salt and tenant-domain separation. The KEK wraps (encrypts) the DEK -- it is never stored anywhere, only recomputed on demand from the passphrase and blob metadata. |
-| **Delta link** | A Microsoft Graph API cursor that marks the point in a mailbox's, drive's, or library's change history where the last backup ended. On the next backup, Atlas uses the delta link to request only changes since that point, making incremental syncs fast. Delta links are stored per-folder (Outlook), per-drive (OneDrive), or per-library (SharePoint) in the snapshot manifest. |
-| **Manifest** | A JSON file stored in S3 that describes a snapshot: list of backed-up items, their storage keys, checksums, paths or folder assignments, and delta links. One manifest file per snapshot. |
-| **Snapshot** | A point-in-time backup record, consisting of a manifest file and the data objects it references. |
-| **Tenant** | A Microsoft 365 organization, identified by its Azure AD tenant ID (a UUID). Each tenant gets its own S3 bucket prefix, its own DEK, and its own set of backups across all workloads. |
-| **Owner** | The Entra object ID of a OneDrive user. CLI commands accept email/UPN and resolve to the object ID automatically. |
-| **Site** | A SharePoint site, identified by URL or Graph site ID (`hostname,site-guid,web-guid`). Each site backup covers all document libraries within that site. |
-| **Replica marker** | A file (`_meta/replica.marker`) written to secondary storage targets on first replication. Atlas checks for this file to detect when a backup command is accidentally run against a replica instead of primary storage. |
+| Term                          | Definition                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DEK** (Data Encryption Key) | A 256-bit symmetric key generated once per tenant and stored as a versioned, self-describing blob at `_meta/dek.enc`. The blob header records the KDF parameters; the DEK itself is AES-256-GCM encrypted with a KEK. All message, attachment, and file ciphertext in the bucket is encrypted with the DEK.                                                                         |
+| **KEK** (Key Encryption Key)  | A key derived from the master passphrase using scrypt (N=65536, r=8, p=1) with a per-wrap random salt and tenant-domain separation. The KEK wraps (encrypts) the DEK -- it is never stored anywhere, only recomputed on demand from the passphrase and blob metadata.                                                                                                               |
+| **Delta link**                | A Microsoft Graph API cursor that marks the point in a mailbox's, drive's, or library's change history where the last backup ended. On the next backup, Atlas uses the delta link to request only changes since that point, making incremental syncs fast. Delta links are stored per-folder (Outlook), per-drive (OneDrive), or per-library (SharePoint) in the snapshot manifest. |
+| **Manifest**                  | A JSON file stored in S3 that describes a snapshot: list of backed-up items, their storage keys, checksums, paths or folder assignments, and delta links. One manifest file per snapshot.                                                                                                                                                                                           |
+| **Snapshot**                  | A point-in-time backup record, consisting of a manifest file and the data objects it references.                                                                                                                                                                                                                                                                                    |
+| **Tenant**                    | A Microsoft 365 organization, identified by its Azure AD tenant ID (a UUID). Each tenant gets its own S3 bucket prefix, its own DEK, and its own set of backups across all workloads.                                                                                                                                                                                               |
+| **Owner**                     | The Entra object ID of a OneDrive user. CLI commands accept email/UPN and resolve to the object ID automatically.                                                                                                                                                                                                                                                                   |
+| **Site**                      | A SharePoint site, identified by URL or Graph site ID (`hostname,site-guid,web-guid`). Each site backup covers all document libraries within that site.                                                                                                                                                                                                                             |
+| **Replica marker**            | A file (`_meta/replica.marker`) written to secondary storage targets on first replication. Atlas checks for this file to detect when a backup command is accidentally run against a replica instead of primary storage.                                                                                                                                                             |
 
 ## See Also
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,6 @@ This precedence means you can set defaults in a config file, keep credentials in
 | `ATLAS_S3_REGION`             | `s3_region`             | no       | S3 region (default: `us-east-1`)               |
 | `ATLAS_ENCRYPTION_PASSPHRASE` | `encryption_passphrase` | yes      | Master passphrase for envelope encryption      |
 
-
 ## The Encrypted Secure Store (`atlas config`)
 
 Storing credentials in plaintext files or environment variables leaves them readable by any process running as your user — environment-grabbing malware routinely sweeps `~/.env`, shell profiles, and process environments. The `atlas config` command instead persists values to `~/.atlas/config.enc`, encrypted with AES-256-GCM:
@@ -108,13 +107,13 @@ The `atlas replicate` command accepts `--target-config` and the `atlas rehydrate
 }
 ```
 
-| Field          | Required | Description                                          |
-| -------------- | -------- | ---------------------------------------------------- |
-| `target_id`    | no       | Stable human-readable ID (auto-derived if omitted)   |
-| `s3_endpoint`  | yes      | S3 endpoint URL for the target                       |
-| `s3_access_key`| yes      | S3 access key for the target                         |
-| `s3_secret_key`| yes      | S3 secret key for the target                         |
-| `s3_region`    | no       | S3 region (default: `us-east-1`)                     |
+| Field           | Required | Description                                        |
+| --------------- | -------- | -------------------------------------------------- |
+| `target_id`     | no       | Stable human-readable ID (auto-derived if omitted) |
+| `s3_endpoint`   | yes      | S3 endpoint URL for the target                     |
+| `s3_access_key` | yes      | S3 access key for the target                       |
+| `s3_secret_key` | yes      | S3 secret key for the target                       |
+| `s3_region`     | no       | S3 region (default: `us-east-1`)                   |
 
 The encryption passphrase is **not** included in this file. Atlas uses the shared encryption model -- the passphrase from the main configuration applies to all targets.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,10 @@
 
 Atlas is published as two npm packages. Choose based on how you plan to run it:
 
-| Package | Command | Best for |
-| ------- | ------- | -------- |
-| **`@wisecom/atlas-cli`** | `npm install -g @wisecom/atlas-cli` | Shell operations, cron/systemd jobs, operator workflows. Reads `.env` automatically. |
-| **`@wisecom/atlas-sdk`** | `npm add @wisecom/atlas-sdk` | Node.js apps, custom schedulers, multi-tenant SaaS, portals. Explicit config, typed API. |
+| Package                  | Command                             | Best for                                                                                 |
+| ------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| **`@wisecom/atlas-cli`** | `npm install -g @wisecom/atlas-cli` | Shell operations, cron/systemd jobs, operator workflows. Reads `.env` automatically.     |
+| **`@wisecom/atlas-sdk`** | `npm add @wisecom/atlas-sdk`        | Node.js apps, custom schedulers, multi-tenant SaaS, portals. Explicit config, typed API. |
 
 Installed the CLI locally instead of globally? A postinstall hook links `atlas` onto your PATH (skipping with a warning if the name is already an alias or another command) — details in the [CLI reference](/reference/cli).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ features:
   - title: Snapshot Replication
     details: Replicate encrypted snapshots to secondary S3 targets for disaster recovery across all workloads.
   - title: CLI & SDK Packages
-    details: "@wisecom/atlas-cli for shell deployment and cron jobs; @wisecom/atlas-sdk for embedding in Node.js apps with a typed, namespaced API."
+    details: '@wisecom/atlas-cli for shell deployment and cron jobs; @wisecom/atlas-sdk for embedding in Node.js apps with a typed, namespaced API.'
   - title: Typed SDK
     details: Programmatic API for embedding in other Node.js applications via the standalone @wisecom/atlas-sdk package.
 ---

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -94,7 +94,7 @@ const status = await atlas.onedrive.checkStatus('owner-id');
 const deletion = await atlas.onedrive.deleteOwnerData('owner-id');
 
 // Replicate and rehydrate
-const offsite = createStorageTarget({ /* ... */ });
+const offsite = createStorageTarget({/* ... */});
 await atlas.onedrive.replicateAll('owner-id', [offsite]);
 await atlas.onedrive.rehydrateOwner('owner-id', offsite);
 ```
@@ -103,33 +103,33 @@ See [Programmatic SDK](./reference/sdk.md) for full method signatures and option
 
 ## CLI Reference
 
-| Command | Description |
-| --- | --- |
-| `atlas onedrive backup` | Back up changed files for one user |
-| `atlas onedrive restore` | Restore files from a snapshot |
-| `atlas onedrive save` | Decrypt and save files from a snapshot to a local zip archive |
-| `atlas onedrive list-snapshots` | List all snapshots for a user |
-| `atlas onedrive list-versions` | Show version history for a file |
-| `atlas onedrive verify` | Verify snapshot blob integrity |
+| Command                         | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
+| `atlas onedrive backup`         | Back up changed files for one user                            |
+| `atlas onedrive restore`        | Restore files from a snapshot                                 |
+| `atlas onedrive save`           | Decrypt and save files from a snapshot to a local zip archive |
+| `atlas onedrive list-snapshots` | List all snapshots for a user                                 |
+| `atlas onedrive list-versions`  | Show version history for a file                               |
+| `atlas onedrive verify`         | Verify snapshot blob integrity                                |
 
 ### `atlas onedrive backup`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) | — |
-| `--full` | Force full crawl, ignore saved delta state | `false` |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                | Description                                | Default        |
+| ------------------- | ------------------------------------------ | -------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required)   | —              |
+| `--full`            | Force full crawl, ignore saved delta state | `false`        |
+| `-t, --tenant <id>` | Tenant identifier                          | Config default |
 
 ### `atlas onedrive restore`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) | — |
-| `-s, --snapshot <id>` | Snapshot to restore from (required) | — |
-| `--target-owner <id>` | Restore to a different user's OneDrive | Same as `--owner` |
-| `--file-filter <paths...>` | Only restore specific files (by ID or path) | All files |
-| `-c, --conflict <mode>` | File conflict policy: `replace`, `rename`, or `fail` | `rename` |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                       | Description                                          | Default           |
+| -------------------------- | ---------------------------------------------------- | ----------------- |
+| `-o, --owner <id>`         | User email or Entra object ID (required)             | —                 |
+| `-s, --snapshot <id>`      | Snapshot to restore from (required)                  | —                 |
+| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner` |
+| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files         |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`          |
+| `-t, --tenant <id>`        | Tenant identifier                                    | Config default    |
 
 Restored files are uploaded to the target user's primary drive. Folders are created as needed (existing folders with the same name are reused, not overwritten). Each file is decrypted, SHA-256 verified against the manifest checksum, and then uploaded using a small-file PUT (&le; 4 MiB) or a resumable upload session (> 4 MiB, with per-chunk retry on 429/503).
 
@@ -139,29 +139,29 @@ Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is 
 
 ### `atlas onedrive list-snapshots`
 
-| Flag | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-t, --tenant <id>` | Tenant identifier |
+| Flag                | Description                              |
+| ------------------- | ---------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required) |
+| `-t, --tenant <id>` | Tenant identifier                        |
 
 ### `atlas onedrive list-versions`
 
-| Flag | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-f, --file <ref>` | File ID or path (required) |
-| `-t, --tenant <id>` | Tenant identifier |
+| Flag                | Description                              |
+| ------------------- | ---------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required) |
+| `-f, --file <ref>`  | File ID or path (required)               |
+| `-t, --tenant <id>` | Tenant identifier                        |
 
 ### `atlas onedrive save`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) | -- |
-| `-s, --snapshot <id>` | Snapshot ID to save from (required) | -- |
-| `--file-filter <paths...>` | Only save specific files (by ID or path) | All files |
-| `-O, --output <path>` | Output zip file path | Auto-generated |
-| `--skip-verify` | Skip SHA-256 integrity checks | `false` |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                       | Description                              | Default        |
+| -------------------------- | ---------------------------------------- | -------------- |
+| `-o, --owner <id>`         | User email or Entra object ID (required) | --             |
+| `-s, --snapshot <id>`      | Snapshot ID to save from (required)      | --             |
+| `--file-filter <paths...>` | Only save specific files (by ID or path) | All files      |
+| `-O, --output <path>`      | Output zip file path                     | Auto-generated |
+| `--skip-verify`            | Skip SHA-256 integrity checks            | `false`        |
+| `-t, --tenant <id>`        | Tenant identifier                        | Config default |
 
 The zip archive preserves the OneDrive folder hierarchy. Files larger than 4 MiB use streaming decryption to avoid holding the full ciphertext in memory.
 
@@ -173,11 +173,11 @@ atlas onedrive save -o user@company.com -s od-snap-123 --file-filter "/Documents
 
 ### `atlas onedrive verify`
 
-| Flag | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-s, --snapshot <id>` | Snapshot ID to verify (required) |
-| `-t, --tenant <id>` | Tenant identifier |
+| Flag                  | Description                              |
+| --------------------- | ---------------------------------------- |
+| `-o, --owner <id>`    | User email or Entra object ID (required) |
+| `-s, --snapshot <id>` | Snapshot ID to verify (required)         |
+| `-t, --tenant <id>`   | Tenant identifier                        |
 
 `atlas onedrive verify` loads the manifest under `onedrive/manifests/{owner_id}/` for the resolved owner and snapshot ID (never listing other owners' prefixes), decrypts each referenced blob, recomputes SHA-256 with `timingSafeEqual`, and checks that the per-file index contains a row for that snapshot.
 
@@ -193,21 +193,23 @@ console.log(`Up to date: ${status.is_up_to_date}`);
 console.log(`Pending changes: ${status.total_pending_changes}`);
 
 for (const drive of status.drives) {
-  console.log(`  ${drive.drive_name}: ${drive.pending_changes} pending, backed up: ${drive.has_backup}`);
+  console.log(
+    `  ${drive.drive_name}: ${drive.pending_changes} pending, backed up: ${drive.has_backup}`,
+  );
 }
 ```
 
 `checkStatus` returns an `OneDriveStatusResult`:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `owner_id` | `string` | The user's Entra object ID |
-| `last_backup_at` | `Date \| undefined` | Timestamp of the most recent snapshot |
-| `last_snapshot_id` | `string \| undefined` | ID of the most recent snapshot |
-| `total_drives` | `number` | Number of drives discovered |
-| `drives` | `OneDriveDriveStatus[]` | Per-drive backup status |
-| `is_up_to_date` | `boolean` | `true` if all drives have been backed up with zero pending changes |
-| `total_pending_changes` | `number` | Sum of pending changes across all drives |
+| Field                   | Type                    | Description                                                        |
+| ----------------------- | ----------------------- | ------------------------------------------------------------------ |
+| `owner_id`              | `string`                | The user's Entra object ID                                         |
+| `last_backup_at`        | `Date \| undefined`     | Timestamp of the most recent snapshot                              |
+| `last_snapshot_id`      | `string \| undefined`   | ID of the most recent snapshot                                     |
+| `total_drives`          | `number`                | Number of drives discovered                                        |
+| `drives`                | `OneDriveDriveStatus[]` | Per-drive backup status                                            |
+| `is_up_to_date`         | `boolean`               | `true` if all drives have been backed up with zero pending changes |
+| `total_pending_changes` | `number`                | Sum of pending changes across all drives                           |
 
 ## Deletion
 
@@ -216,7 +218,7 @@ Delete backed-up OneDrive data via the SDK. The CLI uses the tenant-level `atlas
 **SDK:**
 
 ```typescript
-// Delete all backed-up data for a user (manifests, blobs, indexes, cursors)
+// Erases manifests, blobs, indexes, cursors and staging -- every version of each
 const result = await atlas.onedrive.deleteOwnerData('owner-id');
 console.log(`Deleted: ${result.deleted_objects} objects, ${result.deleted_manifests} manifests`);
 
@@ -224,7 +226,9 @@ console.log(`Deleted: ${result.deleted_objects} objects, ${result.deleted_manife
 await atlas.onedrive.deleteSnapshot('owner-id', 'od-snap-123');
 ```
 
-When Object Lock retention protects objects, deletion reports retained items separately from generic failures.
+`deleteOwnerData` takes the owner's Entra object ID -- the same identifier the storage keys use, which `atlas.resolveUser(email)` returns for an address. It erases every version of every matching object, so the data is gone rather than hidden behind a delete marker in a versioned bucket, and it includes the staging prefix where an interrupted large-file upload parks content.
+
+When Object Lock retention protects objects, deletion reports retained items separately from generic failures. See [Erasure](/security#erasure) for how the two are told apart.
 
 ## Replication
 
@@ -233,7 +237,7 @@ OneDrive snapshots support the same replication workflow as Outlook and SharePoi
 **SDK:**
 
 ```typescript
-const offsite = createStorageTarget({ /* ... */ });
+const offsite = createStorageTarget({/* ... */});
 
 // Replicate a snapshot
 await atlas.onedrive.replicateSnapshot('owner-id', 'od-snap-123', [offsite]);
@@ -257,7 +261,7 @@ A file that refuses to download -- a permissions quirk, a corrupted item, IRM-pr
 3. Each failure is written into the drive's delta cursor as a `failed_items` record: item id, name, reason, attempt count, and when it first failed.
 4. The run is reported **UNHEALTHY** (non-zero exit) for as long as any failure is outstanding.
 
-The record is what makes advancing safe. Graph delta only re-presents items that *changed*, so a failure that was merely logged would be a file that is silently never backed up again. Every run therefore re-fetches its outstanding failures by item ID **before** processing new delta changes:
+The record is what makes advancing safe. Graph delta only re-presents items that _changed_, so a failure that was merely logged would be a file that is silently never backed up again. Every run therefore re-fetches its outstanding failures by item ID **before** processing new delta changes:
 
 - the item downloads → the record is cleared, and it appears in that run's snapshot;
 - the item no longer exists (Graph 404) → the record is dropped silently; there is nothing left to back up;
@@ -296,11 +300,11 @@ Non-critical issues such as historical version download failures or expired vers
 
 Add these to your app registration (in addition to the Outlook backup set):
 
-| Permission | Type | Purpose |
-| --- | --- | --- |
-| `Files.Read.All` | Application | Read all users' OneDrive files (backup, verify) |
-| `Files.ReadWrite.All` | Application | Write to OneDrive (restore only) |
-| `User.Read.All` | Application | Resolve `users/{email}` to object ID for `-o` |
+| Permission            | Type        | Purpose                                         |
+| --------------------- | ----------- | ----------------------------------------------- |
+| `Files.Read.All`      | Application | Read all users' OneDrive files (backup, verify) |
+| `Files.ReadWrite.All` | Application | Write to OneDrive (restore only)                |
+| `User.Read.All`       | Application | Resolve `users/{email}` to object ID for `-o`   |
 
 Outlook backup already expects application permissions such as `Mail.Read` / `Mail.ReadBasic.All`; keep those for mailbox workflows.
 
@@ -308,11 +312,11 @@ Outlook backup already expects application permissions such as `Mail.Read` / `Ma
 
 Implementation thresholds from `@wisecom/atlas-onedrive`:
 
-| Size | Strategy |
-| --- | --- |
-| **≤ 4 MiB** | Single read of the file into memory (pre-authenticated URL or Graph content fallback when needed), encrypt, `put` |
-| **> 4 MiB** and **< 512 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put` |
-| **≥ 512 MiB** | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
+| Size                          | Strategy                                                                                                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **≤ 4 MiB**                   | Single read of the file into memory (pre-authenticated URL or Graph content fallback when needed), encrypt, `put`                                                        |
+| **> 4 MiB** and **< 512 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                |
+| **≥ 512 MiB**                 | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter) so a transient failure replays a single chunk instead of the whole file.
 
@@ -320,11 +324,11 @@ Chunked downloads retry each **4 MiB** range independently (5 attempts with back
 
 A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
 
-| Item | Facets | Backed up |
-| --- | --- | --- |
-| Notebook root (e.g. `Test`) | `folder` + `package` | Treated as a folder. `GET /items/{id}/content` returns **404** -- the root has no content of its own, so there is nothing to store |
-| `<Section>.one` | `file`, MIME `application/msonenote` | Yes -- byte-for-byte, like any other file |
-| `Open Notebook.onetoc2` | `file` | Yes -- byte-for-byte |
+| Item                        | Facets                               | Backed up                                                                                                                          |
+| --------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Notebook root (e.g. `Test`) | `folder` + `package`                 | Treated as a folder. `GET /items/{id}/content` returns **404** -- the root has no content of its own, so there is nothing to store |
+| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes -- byte-for-byte, like any other file                                                                                          |
+| `Open Notebook.onetoc2`     | `file`                               | Yes -- byte-for-byte                                                                                                               |
 
 So notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
 

--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -39,12 +39,12 @@ Delta links are stored in the **encrypted manifest**, not in plaintext. They con
 
 Microsoft Graph applies rate limiting to protect the service. Atlas handles this transparently:
 
-| Error | Behavior |
-| --- | --- |
-| **HTTP 429** (Too Many Requests) | Honors `Retry-After` header, exponential backoff, up to 12 retries |
-| **HTTP 503** (Service Unavailable) | Same retry logic as 429 |
-| **HTTP 504** (Gateway Timeout) | Same retry logic as 429 |
-| **`syncStateNotFound`** | Delta token expired or invalid -- automatic full resync |
+| Error                              | Behavior                                                           |
+| ---------------------------------- | ------------------------------------------------------------------ |
+| **HTTP 429** (Too Many Requests)   | Honors `Retry-After` header, exponential backoff, up to 12 retries |
+| **HTTP 503** (Service Unavailable) | Same retry logic as 429                                            |
+| **HTTP 504** (Gateway Timeout)     | Same retry logic as 429                                            |
+| **`syncStateNotFound`**            | Delta token expired or invalid -- automatic full resync            |
 
 When a delta token has expired (Microsoft purges them after ~30 days of inactivity), Graph returns a `syncStateNotFound` error. Atlas detects this and automatically falls back to a full enumeration for that folder, logging a warning so you know the incremental chain was broken.
 
@@ -54,9 +54,9 @@ The 12-retry limit with exponential backoff means Atlas will wait progressively 
 
 Atlas is designed to handle interruptions safely:
 
-| Action | What Happens |
-| --- | --- |
-| **First Ctrl+C** | Sets interrupt flag. Current delta page finishes processing. All stored objects and completed delta links are saved to a partial manifest. The dashboard marks interrupted folders. |
-| **Second Ctrl+C** | Immediate exit. No manifest is saved for in-progress work. Previously completed folders from this run are still saved. |
+| Action            | What Happens                                                                                                                                                                        |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **First Ctrl+C**  | Sets interrupt flag. Current delta page finishes processing. All stored objects and completed delta links are saved to a partial manifest. The dashboard marks interrupted folders. |
+| **Second Ctrl+C** | Immediate exit. No manifest is saved for in-progress work. Previously completed folders from this run are still saved.                                                              |
 
 The partial manifest from a first Ctrl+C is usable -- subsequent backup runs will pick up where the interruption occurred, thanks to delta links saved for completed folders. Only the interrupted folder needs to re-process from its last saved delta link.

--- a/docs/operations/immutability.md
+++ b/docs/operations/immutability.md
@@ -21,12 +21,12 @@ Without immutability, your backups are only as secure as your S3 credentials. Wi
 
 Atlas supports both S3 Object Lock modes. The difference is significant for operations:
 
-| Property | GOVERNANCE | COMPLIANCE |
-| --- | --- | --- |
-| Protection level | Protected against normal delete/overwrite | Protected against ALL delete/overwrite |
-| Override | Users with `s3:BypassGovernanceRetention` can override | **Nobody** can override, not even the root account |
-| Use case | Day-to-day protection with emergency escape hatch | Regulatory compliance where data must be preserved |
-| Risk | A compromised admin account can bypass it | Accidentally set a 10-year retention? You wait 10 years. |
+| Property         | GOVERNANCE                                             | COMPLIANCE                                               |
+| ---------------- | ------------------------------------------------------ | -------------------------------------------------------- |
+| Protection level | Protected against normal delete/overwrite              | Protected against ALL delete/overwrite                   |
+| Override         | Users with `s3:BypassGovernanceRetention` can override | **Nobody** can override, not even the root account       |
+| Use case         | Day-to-day protection with emergency escape hatch      | Regulatory compliance where data must be preserved       |
+| Risk             | A compromised admin account can bypass it              | Accidentally set a 10-year retention? You wait 10 years. |
 
 ::: danger COMPLIANCE Mode Is Irreversible
 Once an object is written with COMPLIANCE mode retention, it **cannot be deleted by anyone** until the retention period expires. There is no override, no support ticket, no workaround. Choose retention periods carefully. Start with GOVERNANCE mode until you understand the operational implications.
@@ -71,10 +71,10 @@ When Object Lock retention is active, delete commands will partially succeed -- 
 
 When Atlas creates a new bucket, it attempts to configure lifecycle rules compatible with both AWS S3 and MinIO:
 
-| Rule | Purpose |
-| --- | --- |
-| `AbortIncompleteMultipartUpload` (7 days) | Cleans up abandoned upload parts that waste storage |
-| `ExpiredObjectDeleteMarker` | Removes orphaned delete markers left after version-aware deletion |
+| Rule                                      | Purpose                                                           |
+| ----------------------------------------- | ----------------------------------------------------------------- |
+| `AbortIncompleteMultipartUpload` (7 days) | Cleans up abandoned upload parts that waste storage               |
+| `ExpiredObjectDeleteMarker`               | Removes orphaned delete markers left after version-aware deletion |
 
 These rules are best-effort -- if the storage backend does not support lifecycle configuration, Atlas continues without them.
 

--- a/docs/operations/performance-profiling.md
+++ b/docs/operations/performance-profiling.md
@@ -44,29 +44,29 @@ Structured text report          (stdout)
 
 Shows the functions where CPU is actually consumed (excluding time in their callees). A function with high self-time is doing expensive work directly.
 
-| Column | Meaning |
-|--------|---------|
-| Self ms | Milliseconds spent in this function only |
-| Self % | Proportion of total profiled time |
-| Total ms | Time including all callees |
-| Function | Function name |
-| Location | File path and line number |
+| Column   | Meaning                                  |
+| -------- | ---------------------------------------- |
+| Self ms  | Milliseconds spent in this function only |
+| Self %   | Proportion of total profiled time        |
+| Total ms | Time including all callees               |
+| Function | Function name                            |
+| Location | File path and line number                |
 
 ### Domain Breakdown
 
 Aggregates all functions by their Atlas package, giving a high-level view of where compute time goes:
 
-| Domain | What it covers |
-|--------|---------------|
-| `@wisecom/atlas-core/crypto` | Key derivation (scrypt), AES-256-GCM encrypt/decrypt |
-| `@wisecom/atlas-s3` | S3 PutObject/GetObject, MD5 checksum, client operations |
-| `@wisecom/atlas-m365-graph` | Graph client factory, rate limiting, retry logic |
-| `@wisecom/atlas-outlook/backup` | Folder sync, delta processing, attachment storage |
-| `@wisecom/atlas-outlook/restore` | Message reconstruction, folder creation, uploads |
-| `node:crypto` | Native crypto primitives (called by core/crypto) |
-| `node:network` | TLS handshakes, HTTP framing, TCP |
-| `aws-sdk` | AWS SDK v3 internals |
-| `ms-graph-sdk` | Microsoft Graph client library |
+| Domain                           | What it covers                                          |
+| -------------------------------- | ------------------------------------------------------- |
+| `@wisecom/atlas-core/crypto`     | Key derivation (scrypt), AES-256-GCM encrypt/decrypt    |
+| `@wisecom/atlas-s3`              | S3 PutObject/GetObject, MD5 checksum, client operations |
+| `@wisecom/atlas-m365-graph`      | Graph client factory, rate limiting, retry logic        |
+| `@wisecom/atlas-outlook/backup`  | Folder sync, delta processing, attachment storage       |
+| `@wisecom/atlas-outlook/restore` | Message reconstruction, folder creation, uploads        |
+| `node:crypto`                    | Native crypto primitives (called by core/crypto)        |
+| `node:network`                   | TLS handshakes, HTTP framing, TCP                       |
+| `aws-sdk`                        | AWS SDK v3 internals                                    |
+| `ms-graph-sdk`                   | Microsoft Graph client library                          |
 
 ### Hot Paths
 
@@ -91,6 +91,7 @@ This generates both the `.cpuprofile` text report AND an interactive HTML flameg
 **CPU profiles only capture compute time.** Network I/O (waiting for Graph API responses, waiting for S3 uploads to acknowledge) appears as idle time and is NOT reflected in the profile. The profile answers "what is burning CPU?" not "what is the process waiting on?"
 
 For I/O-bound bottleneck analysis:
+
 - Use the `elapsed_ms` timers already present in backup/restore output
 - Compare total wall-clock time vs CPU time -- a large gap indicates I/O dominance
 - Add targeted `performance.now()` spans around suspected network operations

--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -127,7 +127,7 @@ Only unreplicated snapshots are copied (the service diffs manifest lists).
 OneDrive per-owner replication is available through the SDK:
 
 ```typescript
-const offsite = createStorageTarget({ /* ... */ });
+const offsite = createStorageTarget({/* ... */});
 
 // Replicate all unreplicated snapshots for a user
 await atlas.onedrive.replicateAll('owner-id', [offsite]);
@@ -175,7 +175,7 @@ The file contains S3 credentials for the target:
 ```typescript
 import { createAtlasInstance, createStorageTarget } from '@wisecom/atlas-sdk';
 
-const atlas = createAtlasInstance({ /* primary config */ });
+const atlas = createAtlasInstance({/* primary config */});
 
 const offsite = createStorageTarget({
   targetId: 'offsite-dr',
@@ -279,11 +279,13 @@ If primary storage fails and you need to restore from a replica:
 2. **Verify the passphrase** is the same one used when the replica was created.
 
 3. **Run full tenant rehydration:**
+
    ```bash
    atlas rehydrate --all --source-config ./offsite.json
    ```
 
 4. **Verify recovered data:**
+
    ```bash
    atlas outlook list                       # check recovered mailboxes
    atlas outlook verify -m <mailbox> -s <snapshot-id>  # verify Outlook integrity
@@ -292,11 +294,13 @@ If primary storage fails and you need to restore from a replica:
    ```
 
 5. **Run a fresh backup** to capture any changes since the last replication:
+
    ```bash
    atlas outlook backup
    atlas onedrive backup -o <owner>
    atlas sharepoint backup --site <site-url>
    ```
+
    Stale delta links are handled automatically -- Atlas falls back to full sync.
 
 6. **Re-replicate** to ensure the secondary target is current:

--- a/docs/operations/storage-layout.md
+++ b/docs/operations/storage-layout.md
@@ -43,32 +43,32 @@ For managed service providers backing up multiple tenants, this isolation means 
 
 ### Outlook
 
-| Prefix | Contents | Security Notes |
-| --- | --- | --- |
-| `_meta/dek.enc` | Wrapped data encryption key (one per tenant) | **Most critical object** -- losing this means losing access to all tenant data |
-| `data/{mailbox}/` | Encrypted email messages, addressed by SHA-256 | Content is encrypted; S3 metadata is not |
-| `attachments/{mailbox}/` | Encrypted attachments, addressed by SHA-256 | Content is encrypted; S3 metadata is not |
-| `manifests/{mailbox}/` | Encrypted snapshot manifests (JSON) | Contains subjects, folder names, delta URLs -- all encrypted |
+| Prefix                   | Contents                                       | Security Notes                                                                 |
+| ------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| `_meta/dek.enc`          | Wrapped data encryption key (one per tenant)   | **Most critical object** -- losing this means losing access to all tenant data |
+| `data/{mailbox}/`        | Encrypted email messages, addressed by SHA-256 | Content is encrypted; S3 metadata is not                                       |
+| `attachments/{mailbox}/` | Encrypted attachments, addressed by SHA-256    | Content is encrypted; S3 metadata is not                                       |
+| `manifests/{mailbox}/`   | Encrypted snapshot manifests (JSON)            | Contains subjects, folder names, delta URLs -- all encrypted                   |
 
 Each Outlook manifest records an optional `mailbox_purpose` field -- the Graph `mailboxSettings.userPurpose` value (`user`, `shared`, `room`, ...) at backup time. This makes shared mailboxes auditable: they are typically unlicensed and therefore invisible to license-based inventories, but the manifest flag identifies them in the backup catalog. Converting a user mailbox to a shared mailbox keeps its Entra object ID, so the `manifests/{mailbox}/` prefix stays stable across the conversion: manifests written before the conversion read `user`, later ones read `shared`, and content blobs under `data/{mailbox}/` (addressed by SHA-256) are shared across both -- message data is stored once. Manifests written before this field existed simply omit it.
 
 ### OneDrive
 
-| Prefix | Contents | Security Notes |
-| --- | --- | --- |
-| `onedrive/data/{owner_id}/` | Encrypted file blobs, addressed by SHA-256 | Content is encrypted; owner uses opaque Entra object ID |
-| `onedrive/manifests/{owner_id}/` | Encrypted snapshot manifests | Contains file paths, checksums, change types |
-| `onedrive/index/{owner_id}/files/` | Per-file version indexes | Maps file IDs to snapshot versions |
-| `onedrive/_meta/{owner_id}/delta.json` | Encrypted delta cursors | Required for incremental sync |
+| Prefix                                 | Contents                                   | Security Notes                                          |
+| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| `onedrive/data/{owner_id}/`            | Encrypted file blobs, addressed by SHA-256 | Content is encrypted; owner uses opaque Entra object ID |
+| `onedrive/manifests/{owner_id}/`       | Encrypted snapshot manifests               | Contains file paths, checksums, change types            |
+| `onedrive/index/{owner_id}/files/`     | Per-file version indexes                   | Maps file IDs to snapshot versions                      |
+| `onedrive/_meta/{owner_id}/delta.json` | Encrypted delta cursors                    | Required for incremental sync                           |
 
 ### SharePoint
 
-| Prefix | Contents | Security Notes |
-| --- | --- | --- |
-| `sharepoint/data/{site_id}/` | Encrypted file blobs, addressed by SHA-256 | Content is encrypted; site uses Graph site ID |
-| `sharepoint/manifests/{site_id}/` | Encrypted snapshot manifests | Contains file paths, checksums, change types |
-| `sharepoint/index/{site_id}/files/` | Per-file version indexes | Maps file IDs to snapshot versions |
-| `sharepoint/_meta/{site_id}/delta.json` | Encrypted delta cursors | Required for incremental sync |
+| Prefix                                  | Contents                                   | Security Notes                                |
+| --------------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| `sharepoint/data/{site_id}/`            | Encrypted file blobs, addressed by SHA-256 | Content is encrypted; site uses Graph site ID |
+| `sharepoint/manifests/{site_id}/`       | Encrypted snapshot manifests               | Contains file paths, checksums, change types  |
+| `sharepoint/index/{site_id}/files/`     | Per-file version indexes                   | Maps file IDs to snapshot versions            |
+| `sharepoint/_meta/{site_id}/delta.json` | Encrypted delta cursors                    | Required for incremental sync                 |
 
 Subsites are stored exactly like any other site: a subsite is a Graph site with its own `site_id`, so `atlas sharepoint backup --include-subsites` writes one snapshot per subsite under that subsite's own `sharepoint/manifests/{site_id}/` prefix rather than folding its files into the parent site's manifest. Blobs, indexes, and delta cursors follow the same per-`site_id` split, which keeps a subsite's backup, restore, and retention independent of its parent.
 
@@ -98,11 +98,11 @@ Content-addressed storage also makes integrity verification straightforward -- d
 
 Each uploaded object includes S3 metadata headers:
 
-| Header | Value | Encrypted |
-| --- | --- | --- |
-| `x-amz-meta-x-message-id` | Microsoft Graph message ID | **No** -- visible to S3 access |
-| `x-amz-meta-x-plaintext-sha256` | SHA-256 of original plaintext | **No** -- visible to S3 access |
-| `Content-MD5` | MD5 of ciphertext (transport integrity) | N/A -- standard S3 header |
+| Header                          | Value                                   | Encrypted                      |
+| ------------------------------- | --------------------------------------- | ------------------------------ |
+| `x-amz-meta-x-message-id`       | Microsoft Graph message ID              | **No** -- visible to S3 access |
+| `x-amz-meta-x-plaintext-sha256` | SHA-256 of original plaintext           | **No** -- visible to S3 access |
+| `Content-MD5`                   | MD5 of ciphertext (transport integrity) | N/A -- standard S3 header      |
 
 ::: warning Metadata Visibility
 S3 object metadata is **not encrypted**. Anyone with S3 read access (e.g., `s3:GetObject` or `s3:ListBucket` with metadata) can see the Graph message IDs and plaintext hashes. The message **content** is encrypted, but the metadata reveals that specific messages exist and their content hashes. This is a trade-off: metadata enables deduplication checks and integrity verification without decryption, but it leaks existence information.

--- a/docs/reference/cli-recovery.md
+++ b/docs/reference/cli-recovery.md
@@ -45,16 +45,16 @@ atlas outlook restore -m user@company.com -T other@company.com
 atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 ```
 
-| Option                      | Description                                                   |
-| --------------------------- | ------------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Restore from a specific snapshot                              |
-| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                   |
-| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source) |
-| `-f, --folder <name>`       | Restore only messages from this folder or its subfolders      |
+| Option                      | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Restore from a specific snapshot                                |
+| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                     |
+| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source)   |
+| `-f, --folder <name>`       | Restore only messages from this folder or its subfolders        |
 | `--message <ref>`           | Restore a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date               |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date              |
-| `-t, --tenant <id>`         | Override tenant ID                                            |
+| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date                 |
+| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
+| `-t, --tenant <id>`         | Override tenant ID                                              |
 
 Either `--snapshot` or `--mailbox` is required. Using both `--snapshot` and `--mailbox` together requires `--target` (`-T`) to explicitly specify the restore destination. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
 
@@ -83,17 +83,17 @@ atlas outlook save -m user@company.com --start-date 2026-01-01
 atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30
 ```
 
-| Option                      | Description                                                 |
-| --------------------------- | ----------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Save from a specific snapshot                               |
-| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                    |
-| `-f, --folder <name>`       | Save only messages from this folder or its subfolders       |
+| Option                      | Description                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `-s, --snapshot <id>`       | Save from a specific snapshot                                |
+| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                     |
+| `-f, --folder <name>`       | Save only messages from this folder or its subfolders        |
 | `--message <ref>`           | Save a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date             |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date            |
-| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)       |
-| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems) |
-| `-t, --tenant <id>`         | Override tenant ID                                          |
+| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date              |
+| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date             |
+| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
+| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
+| `-t, --tenant <id>`         | Override tenant ID                                           |
 
 The zip archive mirrors the Outlook folder hierarchy:
 
@@ -131,7 +131,7 @@ atlas outlook delete --purge -y                 # skip confirmation prompt
 | `-y, --yes`             | Skip confirmation prompt                                       |
 | `-t, --tenant <id>`     | Override tenant ID                                             |
 
-When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures.
+When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures. "Retained" means a backend named Object Lock as the reason and the object becomes deletable when retention expires. Anything else -- an IAM denial, an unreachable endpoint -- is reported as a failure, because it will not resolve on its own.
 
 ::: details Deletion ordering
 Atlas deletes **manifests first**, then data objects. This ordering is safe: if deletion is interrupted mid-way, you are left with orphan data blobs (harmless, can be cleaned up later) rather than dangling manifest references that point to missing data.
@@ -141,6 +141,8 @@ When using `--snapshot`, only the manifest file is removed -- the underlying dat
 When using `--purge`, **everything** is deleted including the encrypted DEK at `_meta/dek.enc`. This is irreversible -- all data for the tenant becomes permanently inaccessible.
 
 `--purge` and mailbox-wide delete (`-m`) list and delete objects by key only: they do **not** need to unwrap `_meta/dek.enc`. You can use them to empty a bucket even when the wrapped DEK blob is missing, corrupt, or from an older format (you still cannot decrypt data without a valid passphrase and blob).
+
+Deletes remove every noncurrent version, not just the visible key. In a versioned bucket -- required for Object Lock -- deleting a key without a version id only writes a delete marker and leaves the data retrievable. `--purge` sweeps the entire bucket, so OneDrive, SharePoint, and the identity registry go with the Outlook trees; the DEK is removed last and only if nothing survived.
 :::
 
 ## `atlas replicate`
@@ -164,18 +166,18 @@ atlas replicate --status -s <snapshot-id>
 atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
 ```
 
-| Option                       | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
-| `-s, --snapshot <id>`        | Replicate a specific snapshot                         |
-| `-m, --mailbox <email>`      | Replicate all unreplicated snapshots for a mailbox    |
-| `--site <url-or-id>`         | Replicate all unreplicated snapshots for a SharePoint site |
-| `--target-endpoint <url>`    | Target S3 endpoint URL                                |
-| `--target-access-key <key>`  | Target S3 access key                                  |
-| `--target-secret-key <key>`  | Target S3 secret key                                  |
-| `--target-region <region>`   | Target S3 region (default: `us-east-1`)               |
-| `--target-config <path>`     | Path to JSON file with target S3 credentials          |
-| `--status`                   | Show replication status instead of replicating        |
-| `-t, --tenant <id>`          | Override tenant ID                                    |
+| Option                      | Description                                                |
+| --------------------------- | ---------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
+| `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
+| `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
+| `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
+| `--target-access-key <key>` | Target S3 access key                                       |
+| `--target-secret-key <key>` | Target S3 secret key                                       |
+| `--target-region <region>`  | Target S3 region (default: `us-east-1`)                    |
+| `--target-config <path>`    | Path to JSON file with target S3 credentials               |
+| `--status`                  | Show replication status instead of replicating             |
+| `-t, --tenant <id>`         | Override tenant ID                                         |
 
 ::: tip Target Config File
 The target config file is a JSON object with `s3_endpoint`, `s3_access_key`, `s3_secret_key`, and optionally `s3_region` and `target_id`. The encryption passphrase is shared from the main Atlas configuration.
@@ -198,18 +200,18 @@ atlas rehydrate --site https://contoso.sharepoint.com/sites/Engineering --source
 atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --source-config ./offsite.json
 ```
 
-| Option                       | Description                                              |
-| ---------------------------- | -------------------------------------------------------- |
-| `-s, --snapshot <id>`        | Recover a specific snapshot from the replica             |
-| `-m, --mailbox <email>`      | Recover all snapshots for a mailbox from the replica     |
-| `--site <url-or-id>`         | Recover all SharePoint snapshots for a site from the replica |
-| `--all`                      | Recover all mailboxes and snapshots (full tenant DR)     |
-| `--source-endpoint <url>`    | Source replica S3 endpoint URL                           |
-| `--source-access-key <key>`  | Source replica S3 access key                             |
-| `--source-secret-key <key>`  | Source replica S3 secret key                             |
-| `--source-region <region>`   | Source replica S3 region (default: `us-east-1`)          |
-| `--source-config <path>`     | Path to JSON file with source S3 credentials             |
-| `-t, --tenant <id>`          | Override tenant ID                                       |
+| Option                      | Description                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `-s, --snapshot <id>`       | Recover a specific snapshot from the replica                 |
+| `-m, --mailbox <email>`     | Recover all snapshots for a mailbox from the replica         |
+| `--site <url-or-id>`        | Recover all SharePoint snapshots for a site from the replica |
+| `--all`                     | Recover all mailboxes and snapshots (full tenant DR)         |
+| `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
+| `--source-access-key <key>` | Source replica S3 access key                                 |
+| `--source-secret-key <key>` | Source replica S3 secret key                                 |
+| `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
+| `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
+| `-t, --tenant <id>`         | Override tenant ID                                           |
 
 ::: danger Rehydration Is Not Sync
 Rehydration copies explicitly selected data from a designated replica to primary. It does not merge, diff, or resolve conflicts. After rehydration, primary resumes as the source of truth. Delta links in recovered manifests may be stale -- Atlas falls back to full sync on the next backup automatically.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,17 +42,17 @@ atlas outlook backup -C 8                                      # increase parall
 atlas outlook backup --full                                    # force full sync for all mailboxes
 ```
 
-| Option                   | Description                                                    |
-| ------------------------ | -------------------------------------------------------------- |
+| Option                   | Description                                                               |
+| ------------------------ | ------------------------------------------------------------------------- |
 | `-m, --mailbox <id>`     | Specific mailbox to back up (backs up all licensed and shared if omitted) |
-| `-f, --folder <name...>` | Filter to specific folder(s) by name or path (see below)       |
-| `--full`                 | Ignore saved delta links, run full enumeration                 |
-| `-P, --page-size <n>`    | Graph API page size per delta request (1--100, default 10)     |
-| `-C, --concurrency <n>`  | Parallel mailbox count for tenant backup (default 4)           |
-| `--retention-days <n>`   | Apply Object Lock retention for `n` days                       |
-| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`)                |
-| `--require-immutability` | Fail if immutability cannot be enforced                        |
-| `-t, --tenant <id>`      | Override tenant ID from config                                 |
+| `-f, --folder <name...>` | Filter to specific folder(s) by name or path (see below)                  |
+| `--full`                 | Ignore saved delta links, run full enumeration                            |
+| `-P, --page-size <n>`    | Graph API page size per delta request (1--100, default 10)                |
+| `-C, --concurrency <n>`  | Parallel mailbox count for tenant backup (default 4)                      |
+| `--retention-days <n>`   | Apply Object Lock retention for `n` days                                  |
+| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`)                           |
+| `--require-immutability` | Fail if immutability cannot be enforced                                   |
+| `-t, --tenant <id>`      | Override tenant ID from config                                            |
 
 ::: warning Exit codes (all backup commands: Outlook, OneDrive, SharePoint)
 `0` -- complete: every folder/file/mailbox processed without error. `1` -- hard failure: the run aborted (auth, storage, unhandled error). `2` -- **partial**: a snapshot was saved but the run is incomplete -- per-folder/per-file errors, failed mailboxes in a tenant run, or a soft interrupt (Ctrl+C). Failed items are listed on stderr. Schedulers should treat `1` as "page me" and `2` as "warn me": a partial backup is restorable but is missing the listed items. A run is reported complete only when every error bucket is empty (corso's fault-model contract).
@@ -87,15 +87,15 @@ atlas outlook verify -m user@company.com -s <snapshot-id> -t <tenant-id>
 atlas outlook verify -m user@company.com -s <snapshot-id> --fast
 ```
 
-| Option                  | Description                                |
-| ----------------------- | ------------------------------------------ |
-| `-m, --mailbox <email>` | Mailbox that owns the snapshot (required)  |
-| `-s, --snapshot <id>`   | Snapshot identifier to verify (required)   |
-| `-t, --tenant <id>`     | Override tenant ID from config             |
+| Option                  | Description                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `-m, --mailbox <email>` | Mailbox that owns the snapshot (required)                                                   |
+| `-s, --snapshot <id>`   | Snapshot identifier to verify (required)                                                    |
+| `-t, --tenant <id>`     | Override tenant ID from config                                                              |
 | `--fast`                | Existence-only checks (`HeadObject` per referenced key) -- no download, decrypt, or hashing |
 
 ::: details What exactly is verified?
-Verification covers the **merged entry set of the snapshot's manifest chain**: the target delta manifest plus every older manifest of the same mailbox, deduplicated newest-first -- the same routine restore uses, so the two views cannot drift. A corrupt or missing object from an *older* backup run fails verification of every later snapshot that still references it.
+Verification covers the **merged entry set of the snapshot's manifest chain**: the target delta manifest plus every older manifest of the same mailbox, deduplicated newest-first -- the same routine restore uses, so the two views cannot drift. A corrupt or missing object from an _older_ backup run fails verification of every later snapshot that still references it.
 
 Both message blobs and `attachments` are checked (storage key + checksum). Entries with no stored blob at all (e.g. large attachments skipped by pre-v2.1.0 backups) are reported as **unverifiable** and fail the run with a non-zero exit code -- they represent content a restore cannot reproduce.
 
@@ -126,16 +126,16 @@ atlas outlook restore -m user@company.com -T other@company.com
 atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 ```
 
-| Option                      | Description                                                   |
-| --------------------------- | ------------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Restore from a specific snapshot                              |
-| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                   |
-| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source) |
-| `-f, --folder <name>`       | Restore only messages from this folder or its subfolders      |
+| Option                      | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Restore from a specific snapshot                                |
+| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                     |
+| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source)   |
+| `-f, --folder <name>`       | Restore only messages from this folder or its subfolders        |
 | `--message <ref>`           | Restore a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date               |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date              |
-| `-t, --tenant <id>`         | Override tenant ID                                            |
+| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date                 |
+| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
+| `-t, --tenant <id>`         | Override tenant ID                                              |
 
 Either `--snapshot` or `--mailbox` is required. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
 
@@ -170,12 +170,12 @@ atlas outlook read -s <snapshot-id> --message 34
 atlas outlook read -s <snapshot-id> --message 34 --raw
 ```
 
-| Option                | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| `-s, --snapshot <id>` | Snapshot containing the message                           |
+| Option                | Description                                                     |
+| --------------------- | --------------------------------------------------------------- |
+| `-s, --snapshot <id>` | Snapshot containing the message                                 |
 | `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID |
-| `--raw`               | Output full JSON blob instead of formatted headers + body |
-| `-t, --tenant <id>`   | Override tenant ID                                        |
+| `--raw`               | Output full JSON blob instead of formatted headers + body       |
+| `-t, --tenant <id>`   | Override tenant ID                                              |
 
 ### `atlas outlook save`
 
@@ -200,17 +200,17 @@ atlas outlook save -m user@company.com --start-date 2026-01-01
 atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30
 ```
 
-| Option                      | Description                                                 |
-| --------------------------- | ----------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Save from a specific snapshot                               |
-| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                    |
-| `-f, --folder <name>`       | Save only messages from this folder or its subfolders       |
+| Option                      | Description                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `-s, --snapshot <id>`       | Save from a specific snapshot                                |
+| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                     |
+| `-f, --folder <name>`       | Save only messages from this folder or its subfolders        |
 | `--message <ref>`           | Save a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date             |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date            |
-| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)       |
-| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems) |
-| `-t, --tenant <id>`         | Override tenant ID                                          |
+| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date              |
+| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date             |
+| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
+| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
+| `-t, --tenant <id>`         | Override tenant ID                                           |
 
 The zip archive mirrors the Outlook folder hierarchy:
 
@@ -248,7 +248,7 @@ atlas outlook delete --purge -y                 # skip confirmation prompt
 | `-y, --yes`             | Skip confirmation prompt                                       |
 | `-t, --tenant <id>`     | Override tenant ID                                             |
 
-When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures.
+When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures. "Retained" means a backend named Object Lock as the reason and the object becomes deletable when retention expires. Anything else -- an IAM denial, an unreachable endpoint -- is reported as a failure, because it will not resolve on its own.
 
 ::: details Deletion ordering
 Atlas deletes **manifests first**, then data objects. This ordering is safe: if deletion is interrupted mid-way, you are left with orphan data blobs (harmless, can be cleaned up later) rather than dangling manifest references that point to missing data.
@@ -256,6 +256,12 @@ Atlas deletes **manifests first**, then data objects. This ordering is safe: if 
 When using `--snapshot`, only the manifest file is removed -- the underlying data objects are retained because they may be referenced by other snapshots (content-addressed deduplication).
 
 When using `--purge`, **everything** is deleted including the encrypted DEK at `_meta/dek.enc`. This is irreversible -- all data for the tenant becomes permanently inaccessible.
+:::
+
+::: details Erasure in versioned buckets
+Every delete removes the object **and all of its noncurrent versions**. This matters wherever bucket versioning is on -- which is everywhere Object Lock is used, since versioning is its prerequisite. Deleting a key without naming a version writes a delete marker: the object disappears from listings while every byte stays retrievable, so a deletion that reports success would not have erased anything.
+
+`--purge` sweeps the whole bucket rather than a fixed list of prefixes, so Outlook, OneDrive, SharePoint, the identity registry, and any tree a later release adds all go. The encrypted DEK is deleted last, and only if nothing survived: dropping the key while its ciphertext is still retained would leave data that can neither be restored nor be claimed erased.
 :::
 
 ### `atlas outlook status`
@@ -301,10 +307,10 @@ atlas outlook mailboxes --licensed-only
 atlas outlook mailboxes -t <tenant-id>
 ```
 
-| Option              | Description                                                |
-| ------------------- | ---------------------------------------------------------- |
+| Option              | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
 | `--licensed-only`   | Only show mailboxes with an active Exchange Online license (excludes shared mailboxes) |
-| `-t, --tenant <id>` | Override tenant ID from config                             |
+| `-t, --tenant <id>` | Override tenant ID from config                                                         |
 
 ::: tip
 Mailbox size requires the `Reports.Read.All` Graph API permission. If the permission is not granted, the Size column is omitted without error.
@@ -327,23 +333,23 @@ atlas onedrive list-versions -o user@company.com -f "Documents/report.docx"
 atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
 ```
 
-| Option | Description |
-| --- | --- |
-| `backup` | Incremental sync; use `--full` to ignore saved delta state |
-| `restore` | Restore files from a snapshot to the user's (or another user's) OneDrive |
-| `list-snapshots` | List snapshot IDs and timestamps for the owner |
-| `list-versions` | List indexed versions for one file (`-f` file ID or path) |
-| `verify` | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
+| Option           | Description                                                              |
+| ---------------- | ------------------------------------------------------------------------ |
+| `backup`         | Incremental sync; use `--full` to ignore saved delta state               |
+| `restore`        | Restore files from a snapshot to the user's (or another user's) OneDrive |
+| `list-snapshots` | List snapshot IDs and timestamps for the owner                           |
+| `list-versions`  | List indexed versions for one file (`-f` file ID or path)                |
+| `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows    |
 
 **`atlas onedrive backup`**
 
-| Option | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `--full` | Force full crawl ignoring saved delta links |
+| Option                 | Description                                                           |
+| ---------------------- | --------------------------------------------------------------------- |
+| `-o, --owner <id>`     | User email or Entra object ID (required)                              |
+| `--full`               | Force full crawl ignoring saved delta links                           |
 | `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
-| `--lock-mode <mode>` | Object Lock mode (`governance` or `compliance`, default `governance`) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`) |
+| `-t, --tenant <id>`    | Override tenant ID from config                                        |
 
 While the backup runs, a live dashboard shows one row per drive: delta fetch (`fetching changes...`), then per-item progress with rate and ETA, finishing as `[ok]` with stored/dedup/version counts or `[==] up to date` when an incremental delta has no changes. Non-interactive runs (cron/CI) print one plain log line per finished drive instead. Service messages (version syncs, warnings) print above the live region.
 
@@ -353,29 +359,29 @@ Unlike Outlook (which stamps a per-object `retain_until` on each write), OneDriv
 
 **`atlas onedrive restore`**
 
-| Option | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-s, --snapshot <id>` | Snapshot to restore from (required) |
-| `--target-owner <id>` | Restore to a different user's OneDrive (defaults to owner) |
-| `--file-filter <paths...>` | Only restore specific files by ID or path |
-| `-c, --conflict <mode>` | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option                     | Description                                                              |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `-o, --owner <id>`         | User email or Entra object ID (required)                                 |
+| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                      |
+| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)               |
+| `--file-filter <paths...>` | Only restore specific files by ID or path                                |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
+| `-t, --tenant <id>`        | Override tenant ID from config                                           |
 
 **`atlas onedrive list-snapshots`**
 
-| Option | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option              | Description                              |
+| ------------------- | ---------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required) |
+| `-t, --tenant <id>` | Override tenant ID from config           |
 
 **`atlas onedrive list-versions`**
 
-| Option | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-f, --file <ref>` | Graph file ID or drive path (required) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option              | Description                              |
+| ------------------- | ---------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required) |
+| `-f, --file <ref>`  | Graph file ID or drive path (required)   |
+| `-t, --tenant <id>` | Override tenant ID from config           |
 
 **`atlas onedrive save`**
 
@@ -388,14 +394,14 @@ atlas onedrive save -o user@company.com -s od-snap-123 --file-filter "/Documents
 atlas onedrive save -o user@company.com -s od-snap-123 --skip-verify
 ```
 
-| Option | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-s, --snapshot <id>` | OneDrive snapshot ID (required) |
-| `--file-filter <paths...>` | Only save specific files (by ID or path) |
-| `-O, --output <path>` | Output zip file path (default: auto-generated) |
-| `--skip-verify` | Skip SHA-256 integrity checks |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option                     | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID (required)       |
+| `-s, --snapshot <id>`      | OneDrive snapshot ID (required)                |
+| `--file-filter <paths...>` | Only save specific files (by ID or path)       |
+| `-O, --output <path>`      | Output zip file path (default: auto-generated) |
+| `--skip-verify`            | Skip SHA-256 integrity checks                  |
+| `-t, --tenant <id>`        | Override tenant ID from config                 |
 
 The zip archive mirrors the OneDrive folder hierarchy:
 
@@ -412,11 +418,11 @@ Files larger than 4 MiB use streaming decryption to avoid buffering the full cip
 
 **`atlas onedrive verify`**
 
-| Option | Description |
-| --- | --- |
-| `-o, --owner <id>` | User email or Entra object ID (required) |
-| `-s, --snapshot <id>` | OneDrive snapshot id (required) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option                | Description                              |
+| --------------------- | ---------------------------------------- |
+| `-o, --owner <id>`    | User email or Entra object ID (required) |
+| `-s, --snapshot <id>` | OneDrive snapshot id (required)          |
+| `-t, --tenant <id>`   | Override tenant ID from config           |
 
 ::: tip Permissions
 Application permissions `Files.Read.All` and `User.Read.All` are required for backup and read operations; `Files.ReadWrite.All` is additionally required for restore. See Details and storage layout are documented on the [OneDrive Backup](/onedrive-backup) page.
@@ -436,28 +442,28 @@ atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s
 atlas sharepoint verify --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
 ```
 
-| Subcommand | Description |
-| --- | --- |
-| `backup` | Incremental sync; use `--full` to ignore saved delta state |
-| `list-snapshots` | List all SharePoint snapshots for a site |
-| `list-versions` | List all backed-up versions for a specific file |
-| `restore` | Restore files from a snapshot back to the site's document libraries |
-| `save` | Decrypt and save files from a snapshot to a local zip archive |
-| `verify` | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
+| Subcommand       | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `backup`         | Incremental sync; use `--full` to ignore saved delta state            |
+| `list-snapshots` | List all SharePoint snapshots for a site                              |
+| `list-versions`  | List all backed-up versions for a specific file                       |
+| `restore`        | Restore files from a snapshot back to the site's document libraries   |
+| `save`           | Decrypt and save files from a snapshot to a local zip archive         |
+| `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
 
 **`atlas sharepoint backup`**
 
-| Option | Description |
-| --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `--full` | Force full crawl ignoring saved delta links |
-| `--include-subsites` | Also back up every subsite beneath the site, one snapshot per subsite |
+| Option                 | Description                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| `--site <url-or-id>`   | SharePoint site URL or Graph site ID (required)                                   |
+| `--full`               | Force full crawl ignoring saved delta links                                       |
+| `--include-subsites`   | Also back up every subsite beneath the site, one snapshot per subsite             |
 | `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive) |
-| `--lock-mode <mode>` | Object Lock mode (`governance` or `compliance`, default `governance`) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`)             |
+| `-t, --tenant <id>`    | Override tenant ID from config                                                    |
 
 :::: tip Subsites are separate sites
-`GET /sites/{site-id}/sites` returns only a site's *direct* subsites, so Atlas walks the tree explicitly. By default a backup covers the named site alone and emits one warning per uncovered subsite -- classic site collections with nested subsite trees would otherwise look fully protected while entire subsites sat outside the backup.
+`GET /sites/{site-id}/sites` returns only a site's _direct_ subsites, so Atlas walks the tree explicitly. By default a backup covers the named site alone and emits one warning per uncovered subsite -- classic site collections with nested subsite trees would otherwise look fully protected while entire subsites sat outside the backup.
 
 `--include-subsites` backs up the whole tree. Each subsite is a Graph site with its own drives, so it gets **its own snapshot under its own `site_id` prefix** (`sharepoint/manifests/{site_id}/...`), identical in structure to a root-site backup. Restore addressing is therefore unchanged: restore a subsite by naming that subsite.
 
@@ -466,29 +472,29 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 
 **`atlas sharepoint list-snapshots`**
 
-| Option | Description |
-| --- | --- |
+| Option               | Description                                     |
+| -------------------- | ----------------------------------------------- |
 | `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| `-t, --tenant <id>`  | Override tenant ID from config                  |
 
 **`atlas sharepoint list-versions`**
 
-| Option | Description |
-| --- | --- |
+| Option               | Description                                     |
+| -------------------- | ----------------------------------------------- |
 | `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-f, --file <ref>` | File ID or path to look up (required) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| `-f, --file <ref>`   | File ID or path to look up (required)           |
+| `-t, --tenant <id>`  | Override tenant ID from config                  |
 
 **`atlas sharepoint restore`**
 
-| Option | Description |
-| --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-s, --snapshot <id>` | SharePoint snapshot ID (required) |
-| `--target-site <url-or-id>` | Restore to a different site (defaults to original) |
-| `--file-filter <paths...>` | Only restore specific files (by ID or path) |
-| `-c, --conflict <mode>` | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option                      | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                          |
+| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                        |
+| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                       |
+| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                              |
+| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
+| `-t, --tenant <id>`         | Override tenant ID from config                                           |
 
 With `--target-site`, each file goes to the target library whose name matches the
 one it was backed up from, or -- when the restore comes from a single library --
@@ -508,22 +514,22 @@ atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --skip-verify
 ```
 
-| Option | Description |
-| --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-s, --snapshot <id>` | SharePoint snapshot ID (required) |
-| `--file-filter <paths...>` | Only save specific files (by ID or path) |
-| `-O, --output <path>` | Output zip file path (default: auto-generated) |
-| `--skip-verify` | Skip SHA-256 integrity checks |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option                     | Description                                     |
+| -------------------------- | ----------------------------------------------- |
+| `--site <url-or-id>`       | SharePoint site URL or Graph site ID (required) |
+| `-s, --snapshot <id>`      | SharePoint snapshot ID (required)               |
+| `--file-filter <paths...>` | Only save specific files (by ID or path)        |
+| `-O, --output <path>`      | Output zip file path (default: auto-generated)  |
+| `--skip-verify`            | Skip SHA-256 integrity checks                   |
+| `-t, --tenant <id>`        | Override tenant ID from config                  |
 
 **`atlas sharepoint verify`**
 
-| Option | Description |
-| --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-s, --snapshot <id>` | SharePoint snapshot ID (required) |
-| `-t, --tenant <id>` | Override tenant ID from config |
+| Option                | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `--site <url-or-id>`  | SharePoint site URL or Graph site ID (required) |
+| `-s, --snapshot <id>` | SharePoint snapshot ID (required)               |
+| `-t, --tenant <id>`   | Override tenant ID from config                  |
 
 ::: tip Permissions
 Application permissions `Sites.Read.All` and `Files.Read.All` are required for SharePoint backup and verification. Restore additionally requires `Sites.ReadWrite.All`.
@@ -559,15 +565,15 @@ atlas stats --top 5                    # limit owner/site tables to 5 rows
 atlas stats --json                     # raw JSON output
 ```
 
-| Option                  | Description                                                          |
-| ----------------------- | -------------------------------------------------------------------- |
-| `-m, --mailbox <email>` | Outlook statistics for a specific mailbox (implies `--service outlook`) |
-| `-o, --owner <email\|id>` | OneDrive statistics for a specific owner (implies `--service onedrive`) |
-| `-s, --site <url\|id>`  | SharePoint statistics for a specific site (implies `--service sharepoint`) |
-| `--service <name>`      | Limit output to one service: `outlook`, `onedrive`, `sharepoint`, or `all` (default `all`) |
-| `--top <n>`             | Maximum owner/site rows in OneDrive/SharePoint tables (default 20)   |
-| `--json`                | Output raw JSON instead of formatted tables                          |
-| `-t, --tenant <id>`     | Override tenant ID from config                                       |
+| Option                    | Description                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `-m, --mailbox <email>`   | Outlook statistics for a specific mailbox (implies `--service outlook`)                    |
+| `-o, --owner <email\|id>` | OneDrive statistics for a specific owner (implies `--service onedrive`)                    |
+| `-s, --site <url\|id>`    | SharePoint statistics for a specific site (implies `--service sharepoint`)                 |
+| `--service <name>`        | Limit output to one service: `outlook`, `onedrive`, `sharepoint`, or `all` (default `all`) |
+| `--top <n>`               | Maximum owner/site rows in OneDrive/SharePoint tables (default 20)                         |
+| `--json`                  | Output raw JSON instead of formatted tables                                                |
+| `-t, --tenant <id>`       | Override tenant ID from config                                                             |
 
 Only one of `--mailbox`, `--owner`, or `--site` may be used at a time; each scopes the output to its service. OneDrive and SharePoint sections list per-owner and per-site rollups (snapshots, files, size, last backup time) sorted by size descending, so the heaviest consumers surface first. `--owner` accepts an email (resolved via Graph to the owner object ID) or a raw object ID; `--site` accepts a site URL or composite site ID. Use `--json` for programmatic consumption in monitoring scripts or dashboards -- with multiple services the payload is an object keyed by service name, with a single service it is that service's stats object.
 
@@ -584,13 +590,13 @@ atlas config unset client.secret                              # remove from the 
 atlas config validate                                         # live Graph + S3 connectivity check
 ```
 
-| Usage                        | Description                                                    |
-| ---------------------------- | -------------------------------------------------------------- |
-| `config <key> <value>`       | Validate and save a value to the encrypted store               |
-| `config <key>`               | Print the current effective value (secrets masked)             |
-| `config list`                | Print every key with its value and source (`env`, `secure store`, `config file`) |
-| `config unset <key>`         | Remove a key from the encrypted store                          |
-| `config validate`            | Probe Microsoft Graph (token request) and S3 (`ListBuckets`) with the effective config; exits non-zero on failure |
+| Usage                  | Description                                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `config <key> <value>` | Validate and save a value to the encrypted store                                                                  |
+| `config <key>`         | Print the current effective value (secrets masked)                                                                |
+| `config list`          | Print every key with its value and source (`env`, `secure store`, `config file`)                                  |
+| `config unset <key>`   | Remove a key from the encrypted store                                                                             |
+| `config validate`      | Probe Microsoft Graph (token request) and S3 (`ListBuckets`) with the effective config; exits non-zero on failure |
 
 Keys: `tenant.id`, `client.id`, `client.secret`, `s3.endpoint`, `s3.access-key`, `s3.secret-key`, `s3.region`, `encryption.passphrase`. Each value is format-checked on save (GUIDs, URL scheme, 12-character passphrase minimum), and once a credential group is complete the matching live probe runs automatically. Note that `ATLAS_*` environment variables still override stored values; the command warns when a saved value is shadowed.
 
@@ -615,18 +621,18 @@ atlas replicate --status -s <snapshot-id>
 atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
 ```
 
-| Option                       | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
-| `-s, --snapshot <id>`        | Replicate a specific snapshot                         |
-| `-m, --mailbox <email>`      | Replicate all unreplicated snapshots for a mailbox    |
-| `--site <url-or-id>`         | Replicate all unreplicated snapshots for a SharePoint site |
-| `--target-endpoint <url>`    | Target S3 endpoint URL                                |
-| `--target-access-key <key>`  | Target S3 access key                                  |
-| `--target-secret-key <key>`  | Target S3 secret key                                  |
-| `--target-region <region>`   | Target S3 region (default: `us-east-1`)               |
-| `--target-config <path>`     | Path to JSON file with target S3 credentials          |
-| `--status`                   | Show replication status instead of replicating        |
-| `-t, --tenant <id>`          | Override tenant ID                                    |
+| Option                      | Description                                                |
+| --------------------------- | ---------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
+| `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
+| `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
+| `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
+| `--target-access-key <key>` | Target S3 access key                                       |
+| `--target-secret-key <key>` | Target S3 secret key                                       |
+| `--target-region <region>`  | Target S3 region (default: `us-east-1`)                    |
+| `--target-config <path>`    | Path to JSON file with target S3 credentials               |
+| `--status`                  | Show replication status instead of replicating             |
+| `-t, --tenant <id>`         | Override tenant ID                                         |
 
 ::: tip Target Config File
 The target config file is a JSON object with `s3_endpoint`, `s3_access_key`, `s3_secret_key`, and optionally `s3_region` and `target_id`. The encryption passphrase is shared from the main Atlas configuration.
@@ -649,18 +655,18 @@ atlas rehydrate --site https://contoso.sharepoint.com/sites/Engineering --source
 atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --source-config ./offsite.json
 ```
 
-| Option                       | Description                                              |
-| ---------------------------- | -------------------------------------------------------- |
-| `-s, --snapshot <id>`        | Recover a specific snapshot from the replica             |
-| `-m, --mailbox <email>`      | Recover all snapshots for a mailbox from the replica     |
-| `--site <url-or-id>`         | Recover all SharePoint snapshots for a site from the replica |
-| `--all`                      | Recover all mailboxes and snapshots (full tenant DR)     |
-| `--source-endpoint <url>`    | Source replica S3 endpoint URL                           |
-| `--source-access-key <key>`  | Source replica S3 access key                             |
-| `--source-secret-key <key>`  | Source replica S3 secret key                             |
-| `--source-region <region>`   | Source replica S3 region (default: `us-east-1`)          |
-| `--source-config <path>`     | Path to JSON file with source S3 credentials             |
-| `-t, --tenant <id>`          | Override tenant ID                                       |
+| Option                      | Description                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `-s, --snapshot <id>`       | Recover a specific snapshot from the replica                 |
+| `-m, --mailbox <email>`     | Recover all snapshots for a mailbox from the replica         |
+| `--site <url-or-id>`        | Recover all SharePoint snapshots for a site from the replica |
+| `--all`                     | Recover all mailboxes and snapshots (full tenant DR)         |
+| `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
+| `--source-access-key <key>` | Source replica S3 access key                                 |
+| `--source-secret-key <key>` | Source replica S3 secret key                                 |
+| `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
+| `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
+| `-t, --tenant <id>`         | Override tenant ID                                           |
 
 ::: danger Rehydration Is Not Sync
 Rehydration copies explicitly selected data from a designated replica to primary. It does not merge, diff, or resolve conflicts. After rehydration, primary resumes as the source of truth. Delta links in recovered manifests may be stale -- Atlas falls back to full sync on the next backup automatically.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -19,11 +19,7 @@ const atlas = createAtlasInstance({
   encryptionPassphrase: process.env.ATLAS_ENCRYPTION_PASSPHRASE!,
 });
 
-const mailboxes = [
-  'ceo@company.com',
-  'finance@company.com',
-  'legal@company.com',
-];
+const mailboxes = ['ceo@company.com', 'finance@company.com', 'legal@company.com'];
 
 for (const mailbox of mailboxes) {
   const status = await atlas.outlook.checkMailboxStatus(mailbox);
@@ -41,8 +37,8 @@ for (const mailbox of mailboxes) {
 
   console.log(
     `[done] ${mailbox} — snapshot ${result.snapshot.id}, ` +
-    `${result.summary.stored} stored, ${result.summary.deduplicated} deduped, ` +
-    `${result.summary.attachments_stored} attachments (${result.summary.elapsed_ms}ms)`,
+      `${result.summary.stored} stored, ${result.summary.deduplicated} deduped, ` +
+      `${result.summary.attachments_stored} attachments (${result.summary.elapsed_ms}ms)`,
   );
 }
 ```
@@ -93,14 +89,14 @@ async function run_nightly_backup(atlas: AtlasInstance, mailboxes: string[]) {
       if (result.summary.interrupted) {
         console.warn(
           `[warn] ${mailbox} — backup was interrupted, ` +
-          `${result.summary.completed_folder_count}/${result.summary.total_folder_count} folders completed`,
+            `${result.summary.completed_folder_count}/${result.summary.total_folder_count} folders completed`,
         );
       }
 
       if (result.summary.folder_errors.length > 0) {
         console.warn(
           `[warn] ${mailbox} — ${result.summary.folder_errors.length} folder error(s): ` +
-          result.summary.folder_errors.join(', '),
+            result.summary.folder_errors.join(', '),
         );
       }
     } catch (err) {
@@ -127,11 +123,7 @@ const atlas = createAtlasInstance({
   encryptionPassphrase: process.env.ATLAS_ENCRYPTION_PASSPHRASE!,
 });
 
-const mailboxes = [
-  'alice@company.com',
-  'bob@company.com',
-  'carol@company.com',
-];
+const mailboxes = ['alice@company.com', 'bob@company.com', 'carol@company.com'];
 
 const { failed } = await run_nightly_backup(atlas, mailboxes);
 process.exit(failed.length > 0 ? 1 : 0);
@@ -175,7 +167,12 @@ for (const mailbox of mailboxes) {
     // concurrently while the next mailbox backup runs.
     replications.push(atlas.replicateSnapshot(backup.snapshot.id, [offsite]));
 
-    results.push({ mailbox, snapshot_id: backup.snapshot.id, stored: backup.summary.stored, ok: true });
+    results.push({
+      mailbox,
+      snapshot_id: backup.snapshot.id,
+      stored: backup.summary.stored,
+      ok: true,
+    });
   } catch (err) {
     results.push({ mailbox, ok: false, error: (err as Error).message });
   }
@@ -208,13 +205,9 @@ async function verify_recent_backups(atlas: AtlasInstance, mailboxes: string[]) 
     const result = await atlas.outlook.verify(latest.snapshot_id);
 
     if (result.failed.length === 0) {
-      console.log(
-        `[pass] ${mailbox} — ${result.passed}/${result.total_checked} objects verified`,
-      );
+      console.log(`[pass] ${mailbox} — ${result.passed}/${result.total_checked} objects verified`);
     } else {
-      console.error(
-        `[FAIL] ${mailbox} — ${result.failed.length} integrity failure(s):`,
-      );
+      console.error(`[FAIL] ${mailbox} — ${result.failed.length} integrity failure(s):`);
       for (const failure of result.failed) {
         console.error(`  - ${failure}`);
       }
@@ -238,9 +231,9 @@ async function collect_storage_metrics(atlas: AtlasInstance) {
     total_mailboxes: stats.mailbox_count,
     total_snapshots: stats.snapshot_count,
     total_messages: stats.total_messages,
-    total_size_gb: (stats.total_size_bytes / (1024 ** 3)).toFixed(2),
+    total_size_gb: (stats.total_size_bytes / 1024 ** 3).toFixed(2),
     total_attachments: stats.attachment_count,
-    attachment_size_gb: (stats.attachment_size_bytes / (1024 ** 3)).toFixed(2),
+    attachment_size_gb: (stats.attachment_size_bytes / 1024 ** 3).toFixed(2),
   };
 
   console.log(JSON.stringify(metrics, null, 2));
@@ -258,12 +251,12 @@ async function collect_mailbox_metrics(atlas: AtlasInstance, mailbox: string) {
     mailbox: stats.mailbox_id,
     snapshots: stats.snapshot_count,
     messages: stats.total_messages,
-    size_mb: (stats.total_size_bytes / (1024 ** 2)).toFixed(1),
+    size_mb: (stats.total_size_bytes / 1024 ** 2).toFixed(1),
     attachments: stats.attachment_count,
     folders: stats.folders.map((f) => ({
       id: f.folder_id,
       messages: f.message_count,
-      size_mb: (f.total_size_bytes / (1024 ** 2)).toFixed(1),
+      size_mb: (f.total_size_bytes / 1024 ** 2).toFixed(1),
     })),
   };
 }
@@ -274,11 +267,7 @@ async function collect_mailbox_metrics(atlas: AtlasInstance, mailbox: string) {
 Export mailbox backups as `.eml` archives on a schedule -- useful for legal holds, compliance audits, or providing portable copies to departing employees.
 
 ```typescript
-async function export_mailbox_archive(
-  atlas: AtlasInstance,
-  mailbox: string,
-  output_dir: string,
-) {
+async function export_mailbox_archive(atlas: AtlasInstance, mailbox: string, output_dir: string) {
   const timestamp = new Date().toISOString().slice(0, 10);
   const output_path = `${output_dir}/${mailbox.replace('@', '_at_')}_${timestamp}.zip`;
 
@@ -289,14 +278,12 @@ async function export_mailbox_archive(
 
   console.log(
     `[export] ${mailbox} — ${result.saved_count} messages, ` +
-    `${result.attachment_count} attachments, ` +
-    `${(result.total_bytes / (1024 ** 2)).toFixed(1)} MB → ${result.output_path}`,
+      `${result.attachment_count} attachments, ` +
+      `${(result.total_bytes / 1024 ** 2).toFixed(1)} MB → ${result.output_path}`,
   );
 
   if (result.integrity_failures.length > 0) {
-    console.warn(
-      `[warn] ${result.integrity_failures.length} integrity failure(s) during export`,
-    );
+    console.warn(`[warn] ${result.integrity_failures.length} integrity failure(s) during export`);
   }
 
   return result;
@@ -322,7 +309,7 @@ async function validate_immutable_readiness(atlas: AtlasInstance) {
   if (!check.bucket_exists || !check.versioning_enabled || !check.object_lock_enabled) {
     throw new Error(
       'Storage is not ready for immutable backups. ' +
-      'Ensure the bucket exists with versioning and Object Lock enabled.',
+        'Ensure the bucket exists with versioning and Object Lock enabled.',
     );
   }
 
@@ -385,7 +372,7 @@ Discover available mailboxes in the tenant and resolve user identities before ru
 ```typescript
 import { createAtlasInstance } from '@wisecom/atlas-sdk';
 
-const atlas = createAtlasInstance({ /* config */ });
+const atlas = createAtlasInstance({/* config */});
 
 // Discover all tenant mailboxes (licensed users + shared mailboxes)
 const mailboxes = await atlas.outlook.listAvailableMailboxes();
@@ -395,7 +382,9 @@ for (const mb of mailboxes) {
   if (mb.mailbox_purpose === 'shared') {
     console.log(`  ${mb.mail} — ${mb.display_name} (shared mailbox)`);
   } else {
-    console.log(`  ${mb.mail} — ${mb.display_name} (${mb.has_exchange_license ? 'licensed' : 'unlicensed'})`);
+    console.log(
+      `  ${mb.mail} — ${mb.display_name} (${mb.has_exchange_license ? 'licensed' : 'unlicensed'})`,
+    );
   }
 }
 
@@ -425,7 +414,9 @@ const odStatus = await atlas.onedrive.checkStatus('owner-id');
 if (odStatus.is_up_to_date) {
   console.log('[skip] OneDrive is current');
 } else {
-  console.log(`[backup] ${odStatus.total_pending_changes} pending changes across ${odStatus.total_drives} drive(s)`);
+  console.log(
+    `[backup] ${odStatus.total_pending_changes} pending changes across ${odStatus.total_drives} drive(s)`,
+  );
   await atlas.onedrive.backup('owner-id');
 }
 
@@ -435,7 +426,9 @@ const spStatus = await atlas.sharepoint.checkStatus('site-id');
 if (spStatus.is_up_to_date) {
   console.log('[skip] SharePoint site is current');
 } else {
-  console.log(`[backup] ${spStatus.total_pending_changes} pending changes across ${spStatus.total_libraries} library/libraries`);
+  console.log(
+    `[backup] ${spStatus.total_pending_changes} pending changes across ${spStatus.total_libraries} library/libraries`,
+  );
   await atlas.sharepoint.backup('site-id');
 }
 ```
@@ -493,11 +486,7 @@ async function prune_and_replicate_onedrive(
 Clean up old snapshots while keeping recent ones. Useful for environments where storage costs matter and you only need the last N snapshots per mailbox.
 
 ```typescript
-async function prune_old_snapshots(
-  atlas: AtlasInstance,
-  mailbox: string,
-  keep_count: number,
-) {
+async function prune_old_snapshots(atlas: AtlasInstance, mailbox: string, keep_count: number) {
   const snapshots = await atlas.outlook.listSnapshots(mailbox);
 
   if (snapshots.length <= keep_count) {
@@ -511,13 +500,11 @@ async function prune_old_snapshots(
     const result = await atlas.outlook.deleteSnapshot(snapshot.snapshot_id);
     console.log(
       `[prune] ${mailbox} — deleted snapshot ${snapshot.snapshot_id} ` +
-      `(${result.deleted_count} objects removed)`,
+        `(${result.deleted_count} objects removed)`,
     );
   }
 
-  console.log(
-    `[done] ${mailbox} — pruned ${to_delete.length} snapshot(s), kept ${keep_count}`,
-  );
+  console.log(`[done] ${mailbox} — pruned ${to_delete.length} snapshot(s), kept ${keep_count}`);
 }
 ```
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -2,10 +2,10 @@
 
 Atlas ships as two npm packages:
 
-| Package | Install | Use when |
-| ------- | ------- | -------- |
-| **`@wisecom/atlas-cli`** | `npm install -g @wisecom/atlas-cli` | Day-to-day operations from a shell: cron jobs, one-off backups, operator workflows. Reads `.env` and config files. |
-| **`@wisecom/atlas-sdk`** | `npm add @wisecom/atlas-sdk` | Embedding Atlas in your own Node.js app: multi-tenant SaaS, custom schedulers, portals, or automation that needs typed programmatic control. |
+| Package                  | Install                             | Use when                                                                                                                                     |
+| ------------------------ | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`@wisecom/atlas-cli`** | `npm install -g @wisecom/atlas-cli` | Day-to-day operations from a shell: cron jobs, one-off backups, operator workflows. Reads `.env` and config files.                           |
+| **`@wisecom/atlas-sdk`** | `npm add @wisecom/atlas-sdk`        | Embedding Atlas in your own Node.js app: multi-tenant SaaS, custom schedulers, portals, or automation that needs typed programmatic control. |
 
 This page documents **`@wisecom/atlas-sdk`**. For shell commands and flags, see [CLI Commands](/reference/cli).
 
@@ -51,7 +51,10 @@ const snapshots = await atlas.outlook.listSnapshots('user@company.com');
 const verification = await atlas.outlook.verify('snapshot-id');
 const restore = await atlas.outlook.restore('snapshot-id', { folder_name: 'Inbox' });
 const fullRestore = await atlas.outlook.restoreMailbox('user@company.com');
-const save = await atlas.outlook.save('snapshot-id', { folder_name: 'Inbox', output_path: 'backup.zip' });
+const save = await atlas.outlook.save('snapshot-id', {
+  folder_name: 'Inbox',
+  output_path: 'backup.zip',
+});
 const message = await atlas.outlook.readMessage('snapshot-id', '42');
 const status = await atlas.outlook.checkMailboxStatus('user@company.com');
 
@@ -77,25 +80,27 @@ Method names mirror the CLI structure: `atlas outlook backup` maps to `atlas.out
 
 ## Outlook API Reference
 
-| Method | CLI equivalent | Description |
-| ------ | -------------- | ----------- |
-| `backup(mailboxId, options?)` | `atlas outlook backup -m` | Backup a single mailbox |
-| `verify(snapshotId, options?)` | `atlas outlook verify` | Verify full restorable state (chain-aware, incl. attachments); `{ fast: true }` for existence-only |
-| `restore(snapshotId, options?)` | `atlas outlook restore -s` | Restore from a snapshot |
-| `restoreMailbox(mailboxId, options?)` | `atlas outlook restore -m` | Restore all snapshots for a mailbox |
-| `save(snapshotId, options?)` | `atlas outlook save -s` | Export snapshot as EML zip |
-| `saveMailbox(mailboxId, options?)` | `atlas outlook save -m` | Export all snapshots as EML zip |
-| `listMailboxes()` | `atlas outlook list` | List backed-up mailboxes |
-| `listSnapshots(mailboxId)` | `atlas outlook list -m` | List snapshots for a mailbox |
-| `readMessage(snapshotId, messageRef)` | `atlas outlook read` | Read a single message |
-| `checkMailboxStatus(mailboxId)` | `atlas outlook status` | Fast delta peek (pending changes) |
-| `listAvailableMailboxes(options?)` | _(discovery)_ | List all tenant mailboxes via Graph |
-| `deleteMailboxData(mailboxId)` | `atlas outlook delete -m` | Delete all data for a mailbox |
-| `deleteSnapshot(snapshotId)` | `atlas outlook delete -s` | Delete a single snapshot manifest |
-| `purgeTenantData()` | `atlas outlook delete --purge` | Purge entire tenant bucket |
-| `getMailboxStats(mailboxId)` | `atlas stats -m` | Mailbox-level statistics |
+| Method                                | CLI equivalent                 | Description                                                                                        |
+| ------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `backup(mailboxId, options?)`         | `atlas outlook backup -m`      | Backup a single mailbox                                                                            |
+| `verify(snapshotId, options?)`        | `atlas outlook verify`         | Verify full restorable state (chain-aware, incl. attachments); `{ fast: true }` for existence-only |
+| `restore(snapshotId, options?)`       | `atlas outlook restore -s`     | Restore from a snapshot                                                                            |
+| `restoreMailbox(mailboxId, options?)` | `atlas outlook restore -m`     | Restore all snapshots for a mailbox                                                                |
+| `save(snapshotId, options?)`          | `atlas outlook save -s`        | Export snapshot as EML zip                                                                         |
+| `saveMailbox(mailboxId, options?)`    | `atlas outlook save -m`        | Export all snapshots as EML zip                                                                    |
+| `listMailboxes()`                     | `atlas outlook list`           | List backed-up mailboxes                                                                           |
+| `listSnapshots(mailboxId)`            | `atlas outlook list -m`        | List snapshots for a mailbox                                                                       |
+| `readMessage(snapshotId, messageRef)` | `atlas outlook read`           | Read a single message                                                                              |
+| `checkMailboxStatus(mailboxId)`       | `atlas outlook status`         | Fast delta peek (pending changes)                                                                  |
+| `listAvailableMailboxes(options?)`    | _(discovery)_                  | List all tenant mailboxes via Graph                                                                |
+| `deleteMailboxData(mailboxId)`        | `atlas outlook delete -m`      | Delete all data for a mailbox                                                                      |
+| `deleteSnapshot(snapshotId)`          | `atlas outlook delete -s`      | Delete a single snapshot manifest                                                                  |
+| `purgeTenantData()`                   | `atlas outlook delete --purge` | Purge entire tenant bucket                                                                         |
+| `getMailboxStats(mailboxId)`          | `atlas stats -m`               | Mailbox-level statistics                                                                           |
 
 OneDrive and SharePoint expose parallel methods on `atlas.onedrive` and `atlas.sharepoint` (including workload-specific replication). See [OneDrive Backup](/onedrive-backup) and [SharePoint Backup](/sharepoint-backup) for full SDK examples per workload.
+
+Deletion methods erase every version of the objects they match, and `purgeTenantData()` sweeps the whole bucket -- every workload, not only Outlook. The returned `DeletionResult` separates `retained_*` (blocked by Object Lock, deletable once retention expires) from `failed_*` (everything else, which will not clear on its own). See [Erasure](/security#erasure).
 
 ### Shared mailbox identity
 
@@ -116,14 +121,14 @@ const shared = mailboxes.filter((mb) => mb.mailbox_purpose === 'shared');
 
 `atlas.outlook.save` and `atlas.outlook.saveMailbox` accept the following options:
 
-| Option                 | Type      | Description                                               |
-| ---------------------- | --------- | --------------------------------------------------------- |
-| `folder_name`          | `string`  | Save only this folder and its subfolders (name or path)   |
-| `message_ref`          | `string`  | Save a single message by index or ID                      |
-| `start_date`           | `Date`    | Include snapshots on or after this date                   |
-| `end_date`             | `Date`    | Include snapshots on or before this date                  |
-| `output_path`          | `string`  | Output zip file path (default: `Restore-<timestamp>.zip`) |
-| `skip_integrity_check` | `boolean` | Skip SHA-256 verification (default: `false`)              |
+| Option                 | Type                                    | Description                                                                                                                                                                                                                                                |
+| ---------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `folder_name`          | `string`                                | Save only this folder and its subfolders (name or path)                                                                                                                                                                                                    |
+| `message_ref`          | `string`                                | Save a single message by index or ID                                                                                                                                                                                                                       |
+| `start_date`           | `Date`                                  | Include snapshots on or after this date                                                                                                                                                                                                                    |
+| `end_date`             | `Date`                                  | Include snapshots on or before this date                                                                                                                                                                                                                   |
+| `output_path`          | `string`                                | Output zip file path (default: `Restore-<timestamp>.zip`)                                                                                                                                                                                                  |
+| `skip_integrity_check` | `boolean`                               | Skip SHA-256 verification (default: `false`)                                                                                                                                                                                                               |
 | `create_progress`      | `(folders) => TransferProgressReporter` | Progress reporter factory invoked with the folder list before the transfer starts; each reporter callback receives per-folder counts. The CLI injects its dashboard here; SDK callers can plug their own observer. When omitted, progress is not reported. |
 
 Both methods return a `SaveResult`:
@@ -145,13 +150,13 @@ interface SaveResult {
 
 `atlas.outlook.restore` and `atlas.outlook.restoreMailbox` accept the following options:
 
-| Option           | Type     | Description                              |
-| ---------------- | -------- | ---------------------------------------- |
-| `folder_name`    | `string` | Restore only this folder and its subfolders (name or path) |
-| `message_ref`    | `string` | Restore a single message by index or ID  |
-| `target_mailbox` | `string` | Target mailbox for cross-mailbox restore |
-| `start_date`     | `Date`   | Include snapshots on or after this date  |
-| `end_date`       | `Date`   | Include snapshots on or before this date |
+| Option            | Type                                    | Description                                                                                          |
+| ----------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `folder_name`     | `string`                                | Restore only this folder and its subfolders (name or path)                                           |
+| `message_ref`     | `string`                                | Restore a single message by index or ID                                                              |
+| `target_mailbox`  | `string`                                | Target mailbox for cross-mailbox restore                                                             |
+| `start_date`      | `Date`                                  | Include snapshots on or after this date                                                              |
+| `end_date`        | `Date`                                  | Include snapshots on or before this date                                                             |
 | `create_progress` | `(folders) => TransferProgressReporter` | Progress reporter factory; same contract as in Save Options. When omitted, progress is not reported. |
 
 Both methods return a `RestoreResult`:
@@ -199,9 +204,7 @@ The SDK supports snapshot-level replication and disaster recovery rehydration. A
 ```typescript
 import { createAtlasInstance, createStorageTarget } from '@wisecom/atlas-sdk';
 
-const atlas = createAtlasInstance({
-  /* primary config */
-});
+const atlas = createAtlasInstance({/* primary config */});
 
 const offsite = createStorageTarget({
   targetId: 'offsite-dr',
@@ -445,16 +448,16 @@ For future OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant. Y
 
 **Graph cost types:**
 
-| Export                    | Kind  | Description                                                            |
-| ------------------------- | ----- | ---------------------------------------------------------------------- |
-| `OperationCost`           | type  | Per-operation cost breakdown                                           |
-| `ServicePoolCost`         | type  | Cost for a single service pool                                         |
-| `GraphServicePool`        | type  | Pool identifier union type                                             |
-| `GraphServiceLimits`      | type  | Type for the full limits constant                                      |
-| `OutlookServiceLimits`    | type  | Outlook pool limits type                                               |
-| `SharePointServiceLimits` | type  | SharePoint/OneDrive pool limits type                                   |
-| `IdentityServiceLimits`   | type  | Identity pool limits type                                              |
-| `GRAPH_SERVICE_LIMITS`    | value | Frozen official limits constant                                        |
-| `getGraphCost`            | value | Reads the cost burned before a failed operation threw                  |
-| `SyncResult`              | type  | Result of `atlas.outlook.backup` (includes `graph_cost`)                      |
+| Export                    | Kind  | Description                                                                  |
+| ------------------------- | ----- | ---------------------------------------------------------------------------- |
+| `OperationCost`           | type  | Per-operation cost breakdown                                                 |
+| `ServicePoolCost`         | type  | Cost for a single service pool                                               |
+| `GraphServicePool`        | type  | Pool identifier union type                                                   |
+| `GraphServiceLimits`      | type  | Type for the full limits constant                                            |
+| `OutlookServiceLimits`    | type  | Outlook pool limits type                                                     |
+| `SharePointServiceLimits` | type  | SharePoint/OneDrive pool limits type                                         |
+| `IdentityServiceLimits`   | type  | Identity pool limits type                                                    |
+| `GRAPH_SERVICE_LIMITS`    | value | Frozen official limits constant                                              |
+| `getGraphCost`            | value | Reads the cost burned before a failed operation threw                        |
+| `SyncResult`              | type  | Result of `atlas.outlook.backup` (includes `graph_cost`)                     |
 | `RestoreResult`           | type  | Result of `atlas.outlook.restore` / `restoreMailbox` (includes `graph_cost`) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,7 @@ Comprehensive security audit and restore-flow hardening driven by external revie
 - **Restore-integrity verification** — post-restore folder verification integrated into the restore pipeline
 - **Dependency security patches** — Dependabot vulnerability fixes
 
-### v2.0.0 — Multi-Workload & Monorepo *(current branch)*
+### v2.0.0 — Multi-Workload & Monorepo _(current branch)_
 
 Extended Atlas beyond Outlook mailboxes to additional Microsoft 365 workloads and restructured the codebase for independent package releases.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -33,14 +33,14 @@ The KEK is derived using **scrypt**, a memory-hard key derivation function desig
 
 Parameters used by Atlas for **new** DEK wraps:
 
-| Parameter | Value | Purpose |
-| --- | --- | --- |
-| N (cost) | 65536 | CPU/memory cost factor (2^16, OWASP recommendation for sensitive workloads) |
-| r (block size) | 8 | Memory usage multiplier |
-| p (parallelism) | 1 | Sequential derivation (no parallel lanes) |
-| Salt | 32-byte random + tenant domain | Per-wrap random salt combined with length-prefixed `tenant_id` for cross-tenant isolation |
-| Output | 32 bytes (256 bits) | AES-256 key length |
-| Minimum N on unwrap | 16384 | Blobs with weaker parameters are rejected |
+| Parameter           | Value                          | Purpose                                                                                   |
+| ------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| N (cost)            | 65536                          | CPU/memory cost factor (2^16, OWASP recommendation for sensitive workloads)               |
+| r (block size)      | 8                              | Memory usage multiplier                                                                   |
+| p (parallelism)     | 1                              | Sequential derivation (no parallel lanes)                                                 |
+| Salt                | 32-byte random + tenant domain | Per-wrap random salt combined with length-prefixed `tenant_id` for cross-tenant isolation |
+| Output              | 32 bytes (256 bits)            | AES-256 key length                                                                        |
+| Minimum N on unwrap | 16384                          | Blobs with weaker parameters are rejected                                                 |
 
 The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, so re-wrapping the DEK after a passphrase change uses new scrypt parameters without relying on a separate `_meta/kek_params.json` file.
 
@@ -76,15 +76,15 @@ Every encrypt operation generates a **fresh random 12-byte IV** (initialization 
 
 ### What Is Encrypted at Rest
 
-| Data | Encrypted | Notes |
-| --- | --- | --- |
-| Email message bodies | Yes | Stored as encrypted JSON under `data/{mailbox}/{sha256}` |
-| Attachments | Yes | Stored as encrypted blobs under `attachments/{mailbox}/{sha256}` |
-| Manifests | Yes | Contains subjects, folder names, delta URLs, checksums |
-| OneDrive file blobs | Yes | Keys under `onedrive/data/{owner_id}/{sha256}` |
-| OneDrive manifests / indexes / delta state | Yes | Under `onedrive/manifests`, `onedrive/index`, `onedrive/_meta` |
-| Wrapped DEK | Yes | `_meta/dek.enc` is encrypted with the KEK |
-| S3 object metadata | **No** | `x-message-id` on mailbox objects is visible to anyone with S3 read access |
+| Data                                       | Encrypted | Notes                                                                      |
+| ------------------------------------------ | --------- | -------------------------------------------------------------------------- |
+| Email message bodies                       | Yes       | Stored as encrypted JSON under `data/{mailbox}/{sha256}`                   |
+| Attachments                                | Yes       | Stored as encrypted blobs under `attachments/{mailbox}/{sha256}`           |
+| Manifests                                  | Yes       | Contains subjects, folder names, delta URLs, checksums                     |
+| OneDrive file blobs                        | Yes       | Keys under `onedrive/data/{owner_id}/{sha256}`                             |
+| OneDrive manifests / indexes / delta state | Yes       | Under `onedrive/manifests`, `onedrive/index`, `onedrive/_meta`             |
+| Wrapped DEK                                | Yes       | `_meta/dek.enc` is encrypted with the KEK                                  |
+| S3 object metadata                         | **No**    | `x-message-id` on mailbox objects is visible to anyone with S3 read access |
 
 Mailbox objects carry `x-message-id` in S3 metadata for operational diagnostics. OneDrive objects no longer store file identifiers, version identifiers, or plaintext checksums in unencrypted metadata -- all such metadata is stored inside encrypted manifests and version indexes.
 
@@ -108,11 +108,11 @@ There is **no built-in S3 object rename** between email-keyed and ID-keyed mailb
 
 Atlas validates data integrity at three independent layers. Each layer catches a different class of failure:
 
-| Layer | Mechanism | What It Catches | When |
-| --- | --- | --- | --- |
-| **Plaintext** | SHA-256 checksum stored in manifest | Corruption before encryption, application bugs | Backup, verify, save |
-| **Transport** | `Content-MD5` header on S3 PUT | Network corruption during upload (bit flips, truncation) | Every upload (S3 rejects mismatches) |
-| **At-rest** | AES-256-GCM authentication tag | Storage-level tampering or corruption | Every decrypt operation |
+| Layer         | Mechanism                           | What It Catches                                          | When                                 |
+| ------------- | ----------------------------------- | -------------------------------------------------------- | ------------------------------------ |
+| **Plaintext** | SHA-256 checksum stored in manifest | Corruption before encryption, application bugs           | Backup, verify, save                 |
+| **Transport** | `Content-MD5` header on S3 PUT      | Network corruption during upload (bit flips, truncation) | Every upload (S3 rejects mismatches) |
+| **At-rest**   | AES-256-GCM authentication tag      | Storage-level tampering or corruption                    | Every decrypt operation              |
 
 ### How Verification Works
 
@@ -128,6 +128,26 @@ Currently, `atlas outlook verify` checks **message body entries** listed in the 
 ### Content-MD5 on Uploads
 
 Every object uploaded to S3 includes a `Content-MD5` header computed from the **ciphertext** (not the plaintext). This is a transport integrity check -- if a network error corrupts the data in flight, S3 will reject the upload with a checksum mismatch. This is separate from the application-layer SHA-256, which validates the original plaintext content.
+
+## Erasure
+
+Deletion is a security control, not a housekeeping convenience: an erasure request answered incorrectly is a compliance failure that looks like a success.
+
+### Versions are the data
+
+Every Atlas delete removes the object **and each of its noncurrent versions**, addressing them by version id. On a bucket with versioning enabled -- mandatory for Object Lock, so present in every immutability deployment -- a `DeleteObject` call that omits the version id writes a delete marker instead of erasing anything. The object vanishes from listings, the reported count goes up, and the plaintext is still one `GetObject?versionId=` away. Delete markers themselves are swept too, but never counted as erased data, because removing one uncovers versions rather than destroying them.
+
+### A tenant purge sweeps the bucket
+
+`purge_tenant` enumerates the whole bucket rather than a list of known prefixes. Prefix lists go stale as workloads are added -- the tenant tree now holds Outlook, OneDrive, SharePoint, and the identity registry -- and a stale list erases less than the operator was told.
+
+The encrypted DEK is deleted last, and only when the sweep reports nothing left. Removing the key first would produce the worst available outcome: ciphertext that can no longer be restored and cannot be reported as erased either.
+
+### Retained versus failed
+
+A refused delete is classified as **retained** only when the backend names Object Lock as the reason -- AWS answers `AccessDenied: Access Denied because object protected by object lock`, MinIO answers `InvalidRequest: Object is WORM protected and cannot be overwritten`. Retained objects become deletable when their retention window expires, so the operator can wait.
+
+Everything else is a **failure**: a missing `s3:DeleteObjectVersion` permission, an unreachable endpoint, a bucket policy. None of those resolve on their own. Reporting an IAM gap as "retained" would tell an operator that an erasure is on track when nothing is scheduled to happen, so the classifier errs toward failure -- a false alarm costs an investigation, a false all-clear costs the erasure.
 
 ## Replication Security
 

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -29,8 +29,8 @@ Atlas itself is lightweight, but the data it moves is not. A tenant-wide backup 
 
 ## What's Next
 
-| Topic | Description |
-| ----- | ----------- |
-| [Storage Setup](/self-hosting/storage) | Configure MinIO on Docker, bind mounts, RAID, and filesystem recommendations. |
-| [Scheduling & Bandwidth](/self-hosting/scheduling) | Understand bandwidth requirements and automate backups with cron or systemd. |
-| [Replication Setup](/self-hosting/replication) | Set up multi-location replication for a 3-2-1 backup strategy. |
+| Topic                                              | Description                                                                   |
+| -------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [Storage Setup](/self-hosting/storage)             | Configure MinIO on Docker, bind mounts, RAID, and filesystem recommendations. |
+| [Scheduling & Bandwidth](/self-hosting/scheduling) | Understand bandwidth requirements and automate backups with cron or systemd.  |
+| [Replication Setup](/self-hosting/replication)     | Set up multi-location replication for a 3-2-1 backup strategy.                |

--- a/docs/self-hosting/storage.md
+++ b/docs/self-hosting/storage.md
@@ -2,7 +2,6 @@
 
 Atlas stores backups in any S3-compatible object storage. For self-hosted deployments, MinIO running in Docker is the recommended option.
 
-
 ## Bucket Provisioning and Object Lock
 
 Atlas creates each tenant's bucket automatically on first backup (`atlas-{tenant_id}`), and since v2.1.0 creates it **lock-capable**: `CreateBucket` is issued with `ObjectLockEnabledForBucket: true`, which also enables versioning. This is deliberate front-loading -- on both AWS S3 and MinIO, Object Lock can only be enabled at bucket creation (AWS requires a support ticket to retrofit it; MinIO refuses outright). A lock-capable bucket without a retention policy behaves exactly like a normal versioned bucket, so this changes nothing until you opt into immutability with `--retention-days` on a backup command.
@@ -169,7 +168,7 @@ ATLAS_S3_ENDPOINT="https://minio.internal:9000"
 
 Each tenant bucket stores its wrapped data-encryption key at `_meta/dek.enc`. Atlas writes this object exactly once, with a create-only conditional write (`If-None-Match: *`, supported by AWS S3 and MinIO): if two processes bootstrap the same tenant concurrently, the second write fails with `412 Precondition Failed` and that process adopts the already-stored key. Overwriting a live DEK would make every object encrypted with it permanently undecryptable.
 
-As defense in depth, a bucket policy can *mandate* the create-only header on the key object, so even a buggy or outdated client cannot overwrite it (AWS S3; uses the [`s3:if-none-match` condition key](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes-enforce.html)):
+As defense in depth, a bucket policy can _mandate_ the create-only header on the key object, so even a buggy or outdated client cannot overwrite it (AWS S3; uses the [`s3:if-none-match` condition key](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes-enforce.html)):
 
 ```json
 {

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -40,7 +40,7 @@ SharePoint backup makes **progress with accounting**: a file that fails to proce
 - The overall backup result is marked **UNHEALTHY** while any failure is outstanding.
 - Healthy libraries in the same site are unaffected.
 
-Earlier releases discarded a library's entire batch on a single failure and held its cursor back. That traded one bad file for a drive that silently stopped receiving backups -- and left uploaded-but-unreferenced blobs behind. Keeping the successful entries and recording the failure protects everything that *can* be protected while still making the gap impossible to miss.
+Earlier releases discarded a library's entire batch on a single failure and held its cursor back. That traded one bad file for a drive that silently stopped receiving backups -- and left uploaded-but-unreferenced blobs behind. Keeping the successful entries and recording the failure protects everything that _can_ be protected while still making the gap impossible to miss.
 
 ## Storage Layout
 
@@ -132,21 +132,23 @@ console.log(`Up to date: ${status.is_up_to_date}`);
 console.log(`Pending changes: ${status.total_pending_changes}`);
 
 for (const lib of status.libraries) {
-  console.log(`  ${lib.library_name}: ${lib.pending_changes} pending, backed up: ${lib.has_backup}`);
+  console.log(
+    `  ${lib.library_name}: ${lib.pending_changes} pending, backed up: ${lib.has_backup}`,
+  );
 }
 ```
 
 `checkStatus` returns a `SharePointStatusResult`:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `site_id` | `string` | The Graph site ID |
-| `last_backup_at` | `Date \| undefined` | Timestamp of the most recent snapshot |
-| `last_snapshot_id` | `string \| undefined` | ID of the most recent snapshot |
-| `total_libraries` | `number` | Number of document libraries discovered |
-| `libraries` | `SharePointLibraryStatus[]` | Per-library backup status |
-| `is_up_to_date` | `boolean` | `true` if all libraries have been backed up with zero pending changes |
-| `total_pending_changes` | `number` | Sum of pending changes across all libraries |
+| Field                   | Type                        | Description                                                           |
+| ----------------------- | --------------------------- | --------------------------------------------------------------------- |
+| `site_id`               | `string`                    | The Graph site ID                                                     |
+| `last_backup_at`        | `Date \| undefined`         | Timestamp of the most recent snapshot                                 |
+| `last_snapshot_id`      | `string \| undefined`       | ID of the most recent snapshot                                        |
+| `total_libraries`       | `number`                    | Number of document libraries discovered                               |
+| `libraries`             | `SharePointLibraryStatus[]` | Per-library backup status                                             |
+| `is_up_to_date`         | `boolean`                   | `true` if all libraries have been backed up with zero pending changes |
+| `total_pending_changes` | `number`                    | Sum of pending changes across all libraries                           |
 
 ## Deletion
 
@@ -155,7 +157,7 @@ Delete backed-up SharePoint data via the SDK. Per-site and per-snapshot deletion
 **SDK:**
 
 ```typescript
-// Delete all backed-up data for a site (manifests, blobs, indexes, cursors)
+// Erases manifests, blobs, indexes, cursors and staging -- every version of each
 const result = await atlas.sharepoint.deleteSiteData('site-id');
 console.log(`Deleted: ${result.deleted_objects} objects, ${result.deleted_manifests} manifests`);
 
@@ -163,7 +165,9 @@ console.log(`Deleted: ${result.deleted_objects} objects, ${result.deleted_manife
 await atlas.sharepoint.deleteSnapshot('site-id', 'sp-snap-123');
 ```
 
-When Object Lock retention protects objects, deletion reports retained items separately from generic failures.
+`deleteSiteData` erases every version of every matching object, so the data is gone rather than hidden behind a delete marker in a versioned bucket, and it includes the staging prefix where an interrupted large-file upload parks content.
+
+When Object Lock retention protects objects, deletion reports retained items separately from generic failures. See [Erasure](/security#erasure) for how the two are told apart.
 
 ## Site Discovery
 
@@ -185,49 +189,49 @@ console.log(site.id);
 
 ## CLI Reference
 
-| Command | Description |
-| --- | --- |
-| `atlas sharepoint backup` | Back up changed files for a SharePoint site |
-| `atlas sharepoint list-snapshots` | List all snapshots for a site |
-| `atlas sharepoint list-versions` | List all backed-up versions for a specific file |
-| `atlas sharepoint restore` | Restore files from a snapshot to the site |
-| `atlas sharepoint save` | Decrypt and save files from a snapshot to a local zip archive |
-| `atlas sharepoint verify` | Verify snapshot blob integrity |
+| Command                           | Description                                                   |
+| --------------------------------- | ------------------------------------------------------------- |
+| `atlas sharepoint backup`         | Back up changed files for a SharePoint site                   |
+| `atlas sharepoint list-snapshots` | List all snapshots for a site                                 |
+| `atlas sharepoint list-versions`  | List all backed-up versions for a specific file               |
+| `atlas sharepoint restore`        | Restore files from a snapshot to the site                     |
+| `atlas sharepoint save`           | Decrypt and save files from a snapshot to a local zip archive |
+| `atlas sharepoint verify`         | Verify snapshot blob integrity                                |
 
 ### `atlas sharepoint backup`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) | -- |
-| `--full` | Force full crawl, ignore saved delta state | `false` |
-| `--include-subsites` | Back up subsites too (one snapshot per subsite) | `false` |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                 | Description                                     | Default        |
+| -------------------- | ----------------------------------------------- | -------------- |
+| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) | --             |
+| `--full`             | Force full crawl, ignore saved delta state      | `false`        |
+| `--include-subsites` | Back up subsites too (one snapshot per subsite) | `false`        |
+| `-t, --tenant <id>`  | Tenant identifier                               | Config default |
 
 ### `atlas sharepoint list-snapshots`
 
-| Flag | Description |
-| --- | --- |
+| Flag                 | Description                                     |
+| -------------------- | ----------------------------------------------- |
 | `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-t, --tenant <id>` | Tenant identifier |
+| `-t, --tenant <id>`  | Tenant identifier                               |
 
 ### `atlas sharepoint list-versions`
 
-| Flag | Description |
-| --- | --- |
+| Flag                 | Description                                     |
+| -------------------- | ----------------------------------------------- |
 | `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
-| `-f, --file <ref>` | File ID or path to look up (required) |
-| `-t, --tenant <id>` | Tenant identifier |
+| `-f, --file <ref>`   | File ID or path to look up (required)           |
+| `-t, --tenant <id>`  | Tenant identifier                               |
 
 ### `atlas sharepoint restore`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) | -- |
-| `-s, --snapshot <id>` | SharePoint snapshot ID (required) | -- |
-| `--target-site <url-or-id>` | Restore to a different site | Original site |
-| `--file-filter <paths...>` | Only restore specific files (by ID or path) | All files |
-| `-c, --conflict <mode>` | File conflict policy: `replace`, `rename`, or `fail` | `rename` |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                        | Description                                          | Default        |
+| --------------------------- | ---------------------------------------------------- | -------------- |
+| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)      | --             |
+| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                    | --             |
+| `--target-site <url-or-id>` | Restore to a different site                          | Original site  |
+| `--file-filter <paths...>`  | Only restore specific files (by ID or path)          | All files      |
+| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` | `rename`       |
+| `-t, --tenant <id>`         | Tenant identifier                                    | Config default |
 
 #### Where a cross-site restore lands
 
@@ -240,12 +244,12 @@ per entry:
 1. **Same library name.** The target library whose name matches the one the file
    was backed up from -- compared case-insensitively, in Unicode NFC, ignoring
    surrounding whitespace. This keeps a multi-library site's structure intact when
-   the names line up on both ends. If *two* target libraries share that name the
+   the names line up on both ends. If _two_ target libraries share that name the
    choice is ambiguous, so Atlas refuses rather than pick one.
 2. **The only library**, and only when the restore comes from a single source
    library. Library names are localised -- a Finnish tenant's default library is
    `Tiedostot`, an English one's is `Documents` -- so a single-library target must
-   not be decided by name. This rule deliberately does *not* apply when the
+   not be decided by name. This rule deliberately does _not_ apply when the
    snapshot spans several libraries: folding them into one destination merges
    their trees, and two files sharing a path would overwrite each other under
    `--conflict replace`. Restore those one library at a time with `--file-filter`.
@@ -265,14 +269,14 @@ destination. Take a fresh backup to restore by name.
 
 ### `atlas sharepoint save`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) | -- |
-| `-s, --snapshot <id>` | Snapshot ID to save from (required) | -- |
-| `--file-filter <paths...>` | Only save specific files (by ID or path) | All files |
-| `-O, --output <path>` | Output zip file path | Auto-generated |
-| `--skip-verify` | Skip SHA-256 integrity checks | `false` |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                       | Description                                     | Default        |
+| -------------------------- | ----------------------------------------------- | -------------- |
+| `--site <url-or-id>`       | SharePoint site URL or Graph site ID (required) | --             |
+| `-s, --snapshot <id>`      | Snapshot ID to save from (required)             | --             |
+| `--file-filter <paths...>` | Only save specific files (by ID or path)        | All files      |
+| `-O, --output <path>`      | Output zip file path                            | Auto-generated |
+| `--skip-verify`            | Skip SHA-256 integrity checks                   | `false`        |
+| `-t, --tenant <id>`        | Tenant identifier                               | Config default |
 
 The zip archive preserves the SharePoint folder hierarchy from document libraries. Files larger than 4 MiB use streaming decryption to avoid holding the full ciphertext in memory.
 
@@ -283,11 +287,11 @@ atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s
 
 ### `atlas sharepoint verify`
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) | -- |
-| `-s, --snapshot <id>` | Snapshot ID to verify (required) | -- |
-| `-t, --tenant <id>` | Tenant identifier | Config default |
+| Flag                  | Description                                     | Default        |
+| --------------------- | ----------------------------------------------- | -------------- |
+| `--site <url-or-id>`  | SharePoint site URL or Graph site ID (required) | --             |
+| `-s, --snapshot <id>` | Snapshot ID to verify (required)                | --             |
+| `-t, --tenant <id>`   | Tenant identifier                               | Config default |
 
 ## Failed Items and Delta Progress
 
@@ -298,7 +302,7 @@ A file that refuses to download -- a permissions quirk, a corrupted item, IRM-pr
 3. Each failure is written into the drive's delta cursor as a `failed_items` record: item id, name, reason, attempt count, and when it first failed.
 4. The run is reported **UNHEALTHY** (non-zero exit) for as long as any failure is outstanding.
 
-The record is what makes advancing safe. Graph delta only re-presents items that *changed*, so a failure that was merely logged would be a file that is silently never backed up again. Every run therefore re-fetches its outstanding failures by item ID **before** processing new delta changes:
+The record is what makes advancing safe. Graph delta only re-presents items that _changed_, so a failure that was merely logged would be a file that is silently never backed up again. Every run therefore re-fetches its outstanding failures by item ID **before** processing new delta changes:
 
 - the item downloads → the record is cleared, and it appears in that run's snapshot;
 - the item no longer exists (Graph 404) → the record is dropped silently; there is nothing left to back up;
@@ -337,9 +341,9 @@ Non-critical issues such as historical version download failures or expired vers
 
 Add these to your app registration (in addition to any existing Outlook or OneDrive backup permissions):
 
-| Permission | Type | Purpose |
-| --- | --- | --- |
-| `Sites.Read.All` | Application | List sites and read document library metadata |
+| Permission       | Type        | Purpose                                                    |
+| ---------------- | ----------- | ---------------------------------------------------------- |
+| `Sites.Read.All` | Application | List sites and read document library metadata              |
 | `Files.Read.All` | Application | Read file content from document libraries (backup, verify) |
 
 SharePoint backup requires only read permissions (`Sites.Read.All`, `Files.Read.All`). Restore additionally requires `Sites.ReadWrite.All` to upload files back to the site.
@@ -348,11 +352,11 @@ SharePoint backup requires only read permissions (`Sites.Read.All`, `Files.Read.
 
 Implementation thresholds from `@wisecom/atlas-sharepoint`:
 
-| Size | Strategy |
-| --- | --- |
-| **<= 4 MiB** | Single read via pre-authenticated URL (with 429 retry + Retry-After backoff) or Graph content fallback, encrypt, `put` |
-| **> 4 MiB** and **< 512 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put` |
-| **>= 512 MiB** | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
+| Size                          | Strategy                                                                                                                                                                                       |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **<= 4 MiB**                  | Single read via pre-authenticated URL (with 429 retry + Retry-After backoff) or Graph content fallback, encrypt, `put`                                                                         |
+| **> 4 MiB** and **< 512 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                                      |
+| **>= 512 MiB**                | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff) so a transient failure replays a single chunk instead of the whole file.
 
@@ -360,11 +364,11 @@ Chunked downloads retry each **4 MiB** range independently (5 attempts with expo
 
 A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
 
-| Item | Facets | Backed up |
-| --- | --- | --- |
-| Notebook root (e.g. `Test`) | `folder` + `package` | Treated as a folder. `GET /items/{id}/content` returns **404** -- the root has no content of its own, so there is nothing to store |
-| `<Section>.one` | `file`, MIME `application/msonenote` | Yes -- byte-for-byte, like any other file |
-| `Open Notebook.onetoc2` | `file` | Yes -- byte-for-byte |
+| Item                        | Facets                               | Backed up                                                                                                                          |
+| --------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Notebook root (e.g. `Test`) | `folder` + `package`                 | Treated as a folder. `GET /items/{id}/content` returns **404** -- the root has no content of its own, so there is nothing to store |
+| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes -- byte-for-byte, like any other file                                                                                          |
+| `Open Notebook.onetoc2`     | `file`                               | Yes -- byte-for-byte                                                                                                               |
 
 So notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
 
@@ -429,10 +433,10 @@ console.log(`Restored: ${result.files_restored} files, ${result.folders_created}
 
 **File size handling during restore:**
 
-| Size | Strategy |
-| --- | --- |
-| **<= 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content` |
-| **> 4 MiB** | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429/503) |
+| Size         | Strategy                                                                                               |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| **<= 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content`                |
+| **> 4 MiB**  | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429/503) |
 
 Files with `change_type: 'deleted'` or missing `storage_key` are skipped. Checksum verification runs before upload -- corrupted blobs are skipped with a warning.
 
@@ -458,7 +462,7 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-123 --source-
 **SDK:**
 
 ```typescript
-const offsite = createStorageTarget({ /* ... */ });
+const offsite = createStorageTarget({/* ... */});
 
 // Replicate a snapshot
 await atlas.sharepoint.replicateSnapshot('site-id', 'sp-snap-123', [offsite]);
@@ -475,15 +479,15 @@ See [Replication](./operations/replication.md) for the full replication architec
 
 ## Differences from OneDrive Backup
 
-| Aspect | OneDrive | SharePoint |
-| --- | --- | --- |
-| **Scope** | Per-user (owner ID) | Per-site (site ID) |
-| **Target** | User's personal drive | All document libraries in a site |
-| **Storage prefix** | `onedrive/` | `sharepoint/` |
-| **Identity resolution** | Email -> Entra object ID via `GET /users/{email}` | Site URL -> Graph site ID via `GET /sites/{hostname}:/{path}` |
-| **Delta cursor granularity** | One per drive per user | One per document library per site |
-| **Snapshot ID format** | `od-snap-<ms>-<hex>` | `sp-snap-<ms>-<hex>` |
-| **Permissions** | `Files.Read.All` + `User.Read.All` | `Sites.Read.All` + `Files.Read.All` |
+| Aspect                       | OneDrive                                          | SharePoint                                                    |
+| ---------------------------- | ------------------------------------------------- | ------------------------------------------------------------- |
+| **Scope**                    | Per-user (owner ID)                               | Per-site (site ID)                                            |
+| **Target**                   | User's personal drive                             | All document libraries in a site                              |
+| **Storage prefix**           | `onedrive/`                                       | `sharepoint/`                                                 |
+| **Identity resolution**      | Email -> Entra object ID via `GET /users/{email}` | Site URL -> Graph site ID via `GET /sites/{hostname}:/{path}` |
+| **Delta cursor granularity** | One per drive per user                            | One per document library per site                             |
+| **Snapshot ID format**       | `od-snap-<ms>-<hex>`                              | `sp-snap-<ms>-<hex>`                                          |
+| **Permissions**              | `Files.Read.All` + `User.Read.All`                | `Sites.Read.All` + `Files.Read.All`                           |
 
 The encryption, content-addressing, streaming, and version-tracking algorithms are identical between OneDrive and SharePoint backup -- only the scope (user vs. site) and Graph API endpoints differ.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,12 +8,12 @@ Authentication errors appear before any backup activity starts. Atlas authentica
 
 ### AADSTS error codes
 
-| Error Code    | Meaning                        | Fix                                                                                                      |
-| ------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `AADSTS50020` | Wrong tenant ID                | Verify `ATLAS_TENANT_ID` matches the **Directory (tenant) ID** in Azure Portal → Microsoft Entra ID → Overview. |
-| `AADSTS700016` | Wrong client ID or app not found | Verify `ATLAS_CLIENT_ID` matches the **Application (client) ID** in App registrations. The app must exist in the tenant specified by `ATLAS_TENANT_ID`. |
+| Error Code      | Meaning                            | Fix                                                                                                                                                                                                                                  |
+| --------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AADSTS50020`   | Wrong tenant ID                    | Verify `ATLAS_TENANT_ID` matches the **Directory (tenant) ID** in Azure Portal → Microsoft Entra ID → Overview.                                                                                                                      |
+| `AADSTS700016`  | Wrong client ID or app not found   | Verify `ATLAS_CLIENT_ID` matches the **Application (client) ID** in App registrations. The app must exist in the tenant specified by `ATLAS_TENANT_ID`.                                                                              |
 | `AADSTS7000215` | Expired or incorrect client secret | Check the expiry date of your secret in **Certificates & secrets**. If expired, follow the [rotation procedure](/azure-ad-setup#client-secret-rotation). If not expired, verify you copied the secret **Value** (not the Secret ID). |
-| `AADSTS65001` | Admin consent not granted      | Go to **API permissions** for the app registration and click **Grant admin consent for [tenant]**.       |
+| `AADSTS65001`   | Admin consent not granted          | Go to **API permissions** for the app registration and click **Grant admin consent for [tenant]**.                                                                                                                                   |
 
 ### Diagnosing authentication errors
 

--- a/packages/core/src/services/deletion/deletion.service.ts
+++ b/packages/core/src/services/deletion/deletion.service.ts
@@ -11,8 +11,14 @@ import {
 } from '@/services/deletion/shared/prefix-deleter';
 import { logger } from '@/utils/logger';
 
-/** Holds the encrypted DEK; deleted last so a blocked purge stays recoverable. */
-const DEK_PREFIX = '_meta/';
+/**
+ * The wrapped DEK, deleted last so a blocked purge stays recoverable.
+ *
+ * Held back as this exact key, not as the whole `_meta/` prefix: replica markers
+ * and replication status records share that tree and are themselves encrypted
+ * with the DEK, so they have to go before the key that reads them.
+ */
+const DEK_KEY = '_meta/dek.enc';
 
 @injectable()
 export class DeletionService implements DeletionUseCase {
@@ -78,13 +84,13 @@ export class DeletionService implements DeletionUseCase {
   async purge_tenant(tenant_id: string): Promise<DeletionResult> {
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
 
-    const data = await delete_scopes(storage, [''], [DEK_PREFIX]);
+    const data = await delete_scopes(storage, [''], [DEK_KEY]);
     if (has_survivors(data)) {
       logger.error('Tenant purge left objects behind; keeping the DEK so they stay recoverable.');
       return data;
     }
 
-    const dek = await delete_scopes(storage, [DEK_PREFIX]);
+    const dek = await delete_scopes(storage, [DEK_KEY]);
     return merge_deletion_results(data, dek);
   }
 }

--- a/packages/core/src/services/deletion/deletion.service.ts
+++ b/packages/core/src/services/deletion/deletion.service.ts
@@ -3,7 +3,16 @@ import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
 import type { DeletionResult, DeletionUseCase } from '@wisecom/atlas-types';
 import { TENANT_CONTEXT_FACTORY_TOKEN, MANIFEST_REPOSITORY_TOKEN } from '@wisecom/atlas-types';
+import {
+  delete_scopes,
+  empty_deletion_result,
+  has_survivors,
+  merge_deletion_results,
+} from '@/services/deletion/shared/prefix-deleter';
 import { logger } from '@/utils/logger';
+
+/** Holds the encrypted DEK; deleted last so a blocked purge stays recoverable. */
+const DEK_PREFIX = '_meta/';
 
 @injectable()
 export class DeletionService implements DeletionUseCase {
@@ -20,7 +29,7 @@ export class DeletionService implements DeletionUseCase {
   async delete_mailbox_data(tenant_id: string, owner_id: string): Promise<DeletionResult> {
     owner_id = owner_id.toLowerCase();
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
-    return delete_prefixes(storage, [
+    return delete_scopes(storage, [
       `manifests/${owner_id}/`,
       `data/${owner_id}/`,
       `attachments/${owner_id}/`,
@@ -43,7 +52,7 @@ export class DeletionService implements DeletionUseCase {
       }
 
       const key = `manifests/${manifest.owner_id}/${manifest.snapshot_id}.json`;
-      const summary = await delete_prefixes(ctx.storage, [key]);
+      const summary = await delete_scopes(ctx.storage, [key]);
       if (summary.retained_manifests > 0 || summary.failed_manifests > 0) {
         logger.error('Snapshot manifest is protected by Object Lock and cannot be deleted yet.');
       }
@@ -54,134 +63,28 @@ export class DeletionService implements DeletionUseCase {
   }
 
   /**
-   * Removes everything in the tenant bucket: data, attachments, manifests, and _meta
-   * (including the encrypted DEK). This is irreversible.
+   * Removes every object in the tenant bucket, including the encrypted DEK.
+   * This is irreversible.
+   *
+   * The sweep covers the whole bucket rather than a list of known prefixes.
+   * Each workload owns its own tree -- Outlook at the root, OneDrive and
+   * SharePoint under theirs, plus loose keys like the identity registry -- and
+   * an enumerated list silently stops erasing whatever ships next (issue #27).
+   *
+   * The DEK goes last and only if nothing survived: dropping the key while its
+   * ciphertext is still retained would leave data that can neither be restored
+   * nor claimed erased.
    */
   async purge_tenant(tenant_id: string): Promise<DeletionResult> {
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
-    const core = await delete_prefixes(storage, ['manifests/', 'data/', 'attachments/']);
-    if (
-      core.retained_objects > 0 ||
-      core.retained_manifests > 0 ||
-      core.failed_objects > 0 ||
-      core.failed_manifests > 0
-    ) {
-      return core;
+
+    const data = await delete_scopes(storage, [''], [DEK_PREFIX]);
+    if (has_survivors(data)) {
+      logger.error('Tenant purge left objects behind; keeping the DEK so they stay recoverable.');
+      return data;
     }
 
-    const meta = await delete_prefixes(storage, ['_meta/']);
-    return {
-      deleted_objects: core.deleted_objects + meta.deleted_objects,
-      deleted_manifests: core.deleted_manifests + meta.deleted_manifests,
-      retained_objects: core.retained_objects + meta.retained_objects,
-      retained_manifests: core.retained_manifests + meta.retained_manifests,
-      failed_objects: core.failed_objects + meta.failed_objects,
-      failed_manifests: core.failed_manifests + meta.failed_manifests,
-    };
+    const dek = await delete_scopes(storage, [DEK_PREFIX]);
+    return merge_deletion_results(data, dek);
   }
-}
-
-interface DeletionStorage {
-  delete(key: string): Promise<void>;
-  list(prefix: string): Promise<string[]>;
-  list_versions(prefix: string): Promise<{ key: string; version_id: string }[]>;
-  delete_version(key: string, version_id: string): Promise<void>;
-}
-
-type DeletionSummaryMutable = {
-  deleted_objects: number;
-  deleted_manifests: number;
-  retained_objects: number;
-  retained_manifests: number;
-  failed_objects: number;
-  failed_manifests: number;
-};
-
-/** Deletes all versions (or current keys) under the provided prefixes/keys. */
-async function delete_prefixes(
-  storage: DeletionStorage,
-  scopes: string[],
-): Promise<DeletionResult> {
-  const summary = empty_deletion_summary();
-
-  for (const scope of scopes) {
-    const version_entries = await storage.list_versions(scope);
-    if (version_entries.length > 0) {
-      for (const version of version_entries) {
-        await delete_versioned_key(storage, version, summary);
-      }
-      continue;
-    }
-
-    const visible_keys = await storage.list(scope);
-    for (const key of visible_keys) {
-      await delete_single_key(storage, key, summary);
-    }
-  }
-
-  return { ...summary };
-}
-
-async function delete_versioned_key(
-  storage: DeletionStorage,
-  version: { key: string; version_id: string },
-  summary: DeletionSummaryMutable,
-): Promise<void> {
-  try {
-    await storage.delete_version(version.key, version.version_id);
-    increment_summary(summary, version.key, 'deleted');
-  } catch (err) {
-    const bucket = is_object_lock_delete_error(err) ? 'retained' : 'failed';
-    increment_summary(summary, version.key, bucket);
-  }
-}
-
-async function delete_single_key(
-  storage: DeletionStorage,
-  key: string,
-  summary: DeletionSummaryMutable,
-): Promise<void> {
-  try {
-    await storage.delete(key);
-    increment_summary(summary, key, 'deleted');
-  } catch (err) {
-    const bucket = is_object_lock_delete_error(err) ? 'retained' : 'failed';
-    increment_summary(summary, key, bucket);
-  }
-}
-
-function increment_summary(
-  summary: DeletionSummaryMutable,
-  key: string,
-  outcome: 'deleted' | 'retained' | 'failed',
-): void {
-  const suffix = key.startsWith('manifests/') ? 'manifests' : 'objects';
-  const field = `${outcome}_${suffix}` as keyof DeletionSummaryMutable;
-  summary[field]++;
-}
-
-function is_object_lock_delete_error(err: unknown): boolean {
-  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
-  return (
-    message.includes('object lock') ||
-    message.includes('retention') ||
-    message.includes('worm protected') ||
-    message.includes('accessdenied') ||
-    message.includes('operationaborted')
-  );
-}
-
-function empty_deletion_summary(): DeletionSummaryMutable {
-  return {
-    deleted_objects: 0,
-    deleted_manifests: 0,
-    retained_objects: 0,
-    retained_manifests: 0,
-    failed_objects: 0,
-    failed_manifests: 0,
-  };
-}
-
-function empty_deletion_result(): DeletionResult {
-  return empty_deletion_summary();
 }

--- a/packages/core/src/services/deletion/onedrive-deletion.service.ts
+++ b/packages/core/src/services/deletion/onedrive-deletion.service.ts
@@ -5,6 +5,7 @@ import type {
   DeletionResult,
 } from '@wisecom/atlas-types';
 import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import { delete_scopes } from '@/services/deletion/shared/prefix-deleter';
 
 @injectable()
 export class OneDriveDeletionService implements OneDriveDeletionUseCase {
@@ -12,19 +13,22 @@ export class OneDriveDeletionService implements OneDriveDeletionUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
   ) {}
 
-  /** Deletes all backed-up OneDrive data for a single owner. */
+  /**
+   * Deletes all backed-up OneDrive data for a single owner.
+   *
+   * Staging is swept alongside the rest: a large-file upload interrupted before
+   * its canonical copy leaves the file content parked there, and the backup path
+   * only clears it opportunistically.
+   */
   async delete_owner_data(tenant_id: string, owner_id: string): Promise<DeletionResult> {
-    const ctx = await this._tenant_factory.create(tenant_id);
-    try {
-      return await delete_prefixes(ctx.storage, [
-        `onedrive/manifests/${owner_id}/`,
-        `onedrive/data/${owner_id}/`,
-        `onedrive/index/${owner_id}/`,
-        `onedrive/_meta/${owner_id}/`,
-      ]);
-    } finally {
-      ctx.destroy();
-    }
+    const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    return delete_scopes(storage, [
+      `onedrive/manifests/${owner_id}/`,
+      `onedrive/data/${owner_id}/`,
+      `onedrive/index/${owner_id}/`,
+      `onedrive/_meta/${owner_id}/`,
+      `onedrive/staging/${owner_id}/`,
+    ]);
   }
 
   /**
@@ -36,91 +40,7 @@ export class OneDriveDeletionService implements OneDriveDeletionUseCase {
     owner_id: string,
     snapshot_id: string,
   ): Promise<DeletionResult> {
-    const ctx = await this._tenant_factory.create(tenant_id);
-    try {
-      const key = `onedrive/manifests/${owner_id}/${snapshot_id}.json`;
-      const summary = empty_deletion_summary();
-      await delete_single_key(ctx.storage, key, summary);
-      return { ...summary };
-    } finally {
-      ctx.destroy();
-    }
+    const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    return delete_scopes(storage, [`onedrive/manifests/${owner_id}/${snapshot_id}.json`]);
   }
-}
-
-interface DeletionStorage {
-  delete(key: string): Promise<void>;
-  list(prefix: string): Promise<string[]>;
-}
-
-type DeletionSummaryMutable = {
-  deleted_objects: number;
-  deleted_manifests: number;
-  retained_objects: number;
-  retained_manifests: number;
-  failed_objects: number;
-  failed_manifests: number;
-};
-
-/** Lists and deletes all keys under the provided prefixes. */
-async function delete_prefixes(
-  storage: DeletionStorage,
-  prefixes: string[],
-): Promise<DeletionResult> {
-  const summary = empty_deletion_summary();
-
-  for (const prefix of prefixes) {
-    const keys = await storage.list(prefix);
-    for (const key of keys) {
-      await delete_single_key(storage, key, summary);
-    }
-  }
-
-  return { ...summary };
-}
-
-async function delete_single_key(
-  storage: DeletionStorage,
-  key: string,
-  summary: DeletionSummaryMutable,
-): Promise<void> {
-  try {
-    await storage.delete(key);
-    increment_summary(summary, key, 'deleted');
-  } catch (err) {
-    const bucket = is_object_lock_delete_error(err) ? 'retained' : 'failed';
-    increment_summary(summary, key, bucket);
-  }
-}
-
-function increment_summary(
-  summary: DeletionSummaryMutable,
-  key: string,
-  outcome: 'deleted' | 'retained' | 'failed',
-): void {
-  const suffix = key.startsWith('onedrive/manifests/') ? 'manifests' : 'objects';
-  const field = `${outcome}_${suffix}` as keyof DeletionSummaryMutable;
-  summary[field]++;
-}
-
-function is_object_lock_delete_error(err: unknown): boolean {
-  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
-  return (
-    message.includes('object lock') ||
-    message.includes('retention') ||
-    message.includes('worm protected') ||
-    message.includes('accessdenied') ||
-    message.includes('operationaborted')
-  );
-}
-
-function empty_deletion_summary(): DeletionSummaryMutable {
-  return {
-    deleted_objects: 0,
-    deleted_manifests: 0,
-    retained_objects: 0,
-    retained_manifests: 0,
-    failed_objects: 0,
-    failed_manifests: 0,
-  };
 }

--- a/packages/core/src/services/deletion/shared/prefix-deleter.ts
+++ b/packages/core/src/services/deletion/shared/prefix-deleter.ts
@@ -31,6 +31,11 @@ type MutableResult = {
  * Deletes every version under each scope, where a scope is a key prefix or one
  * exact key.
  *
+ * ponytail: one listing buffered per scope, one DELETE per version, measured at
+ * ~1500 versions in 2.6s. Fine for a tenant; if million-object buckets show up,
+ * switch to the DeleteObjects batch API (1000 per call) and map its per-key
+ * error entries onto the same retained/failed split.
+ *
  * @param skip_prefixes - Scopes left untouched. A tenant purge uses this to hold
  *   the encrypted DEK back until the data it protects is confirmed gone.
  */
@@ -132,8 +137,12 @@ function count(
   outcome: 'deleted' | 'retained' | 'failed',
 ): void {
   // Removing a delete marker uncovers the versions beneath it rather than
-  // erasing anything, so it is swept but never counted as data.
-  if ('is_delete_marker' in entry && entry.is_delete_marker === true) return;
+  // erasing anything, so a successful sweep of one is not counted as data. A
+  // marker we could not remove still counts: it is an entry that outlived the
+  // sweep, and a purge must not read the summary as clean and drop the DEK.
+  if (outcome === 'deleted' && 'is_delete_marker' in entry && entry.is_delete_marker === true) {
+    return;
+  }
 
   const kind = is_manifest_key(entry.key) ? 'manifests' : 'objects';
   summary[`${outcome}_${kind}` as keyof MutableResult]++;

--- a/packages/core/src/services/deletion/shared/prefix-deleter.ts
+++ b/packages/core/src/services/deletion/shared/prefix-deleter.ts
@@ -1,0 +1,172 @@
+/**
+ * The single deletion primitive behind Outlook, OneDrive and SharePoint erasure.
+ *
+ * Deleting a key without a version id is not erasure. In a versioned bucket --
+ * the prerequisite for Object Lock, so every immutability deployment has one --
+ * `DeleteObject` writes a delete marker and leaves the bytes retrievable as a
+ * noncurrent version. Everything here therefore deletes by version id, and falls
+ * back to plain keys only for backends that do not enumerate versions.
+ */
+
+import type { DeletionResult, StorageObjectVersion } from '@wisecom/atlas-types';
+
+/** The slice of ObjectStorage that erasure needs. */
+export interface DeletionStorage {
+  delete(key: string): Promise<void>;
+  list(prefix: string): Promise<string[]>;
+  list_versions(prefix: string): Promise<readonly StorageObjectVersion[]>;
+  delete_version(key: string, version_id: string): Promise<void>;
+}
+
+type MutableResult = {
+  deleted_objects: number;
+  deleted_manifests: number;
+  retained_objects: number;
+  retained_manifests: number;
+  failed_objects: number;
+  failed_manifests: number;
+};
+
+/**
+ * Deletes every version under each scope, where a scope is a key prefix or one
+ * exact key.
+ *
+ * @param skip_prefixes - Scopes left untouched. A tenant purge uses this to hold
+ *   the encrypted DEK back until the data it protects is confirmed gone.
+ */
+export async function delete_scopes(
+  storage: DeletionStorage,
+  scopes: readonly string[],
+  skip_prefixes: readonly string[] = [],
+): Promise<DeletionResult> {
+  const summary = empty_summary();
+
+  for (const scope of scopes) {
+    const versions = await storage.list_versions(scope);
+
+    if (versions.length > 0) {
+      for (const version of manifests_first(versions, (v) => v.key)) {
+        if (is_skipped(version.key, skip_prefixes)) continue;
+        await delete_one(storage, version, summary);
+      }
+      continue;
+    }
+
+    // No version listing: the visible key is all this backend can offer.
+    for (const key of manifests_first(await storage.list(scope), (k) => k)) {
+      if (is_skipped(key, skip_prefixes)) continue;
+      await delete_one(storage, { key }, summary);
+    }
+  }
+
+  return { ...summary };
+}
+
+/** Adds two deletion summaries, for callers that erase in more than one pass. */
+export function merge_deletion_results(a: DeletionResult, b: DeletionResult): DeletionResult {
+  return {
+    deleted_objects: a.deleted_objects + b.deleted_objects,
+    deleted_manifests: a.deleted_manifests + b.deleted_manifests,
+    retained_objects: a.retained_objects + b.retained_objects,
+    retained_manifests: a.retained_manifests + b.retained_manifests,
+    failed_objects: a.failed_objects + b.failed_objects,
+    failed_manifests: a.failed_manifests + b.failed_manifests,
+  };
+}
+
+/** True when anything survived the sweep, whether locked or merely broken. */
+export function has_survivors(result: DeletionResult): boolean {
+  return (
+    result.retained_objects > 0 ||
+    result.retained_manifests > 0 ||
+    result.failed_objects > 0 ||
+    result.failed_manifests > 0
+  );
+}
+
+/** An all-zero summary, for callers that find nothing to delete. */
+export function empty_deletion_result(): DeletionResult {
+  return empty_summary();
+}
+
+function is_skipped(key: string, skip_prefixes: readonly string[]): boolean {
+  return skip_prefixes.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Orders manifests ahead of the objects they reference.
+ *
+ * An interrupted deletion then leaves orphan blobs, which are harmless and
+ * cleanable, rather than manifests pointing at data that is already gone.
+ * Sweeping a whole bucket would otherwise hit `data/` long before `manifests/`.
+ */
+function manifests_first<T>(entries: readonly T[], key_of: (entry: T) => string): T[] {
+  return [...entries].sort(
+    (a, b) => Number(is_manifest_key(key_of(b))) - Number(is_manifest_key(key_of(a))),
+  );
+}
+
+/** True for manifest keys at any depth: `manifests/…` and `onedrive/manifests/…`. */
+function is_manifest_key(key: string): boolean {
+  return key.split('/').includes('manifests');
+}
+
+async function delete_one(
+  storage: DeletionStorage,
+  entry: StorageObjectVersion | { key: string },
+  summary: MutableResult,
+): Promise<void> {
+  const version_id = 'version_id' in entry ? entry.version_id : undefined;
+  try {
+    if (version_id === undefined) await storage.delete(entry.key);
+    else await storage.delete_version(entry.key, version_id);
+    count(summary, entry, 'deleted');
+  } catch (err) {
+    count(summary, entry, is_object_lock_delete_error(err) ? 'retained' : 'failed');
+  }
+}
+
+function count(
+  summary: MutableResult,
+  entry: StorageObjectVersion | { key: string },
+  outcome: 'deleted' | 'retained' | 'failed',
+): void {
+  // Removing a delete marker uncovers the versions beneath it rather than
+  // erasing anything, so it is swept but never counted as data.
+  if ('is_delete_marker' in entry && entry.is_delete_marker === true) return;
+
+  const kind = is_manifest_key(entry.key) ? 'manifests' : 'objects';
+  summary[`${outcome}_${kind}` as keyof MutableResult]++;
+}
+
+/**
+ * True only for errors that name Object Lock as the reason a delete was refused.
+ *
+ * Backends word it differently -- MinIO raises `InvalidRequest` "Object is WORM
+ * protected and cannot be overwritten", AWS raises `AccessDenied` "Access Denied
+ * because object protected by object lock" -- but both name the mechanism. A
+ * bare `AccessDenied` from a missing IAM permission does not, and must not be
+ * filed as "retained, deletable once retention expires". On an erasure report a
+ * false alarm costs an investigation; a false all-clear costs the erasure.
+ */
+function is_object_lock_delete_error(err: unknown): boolean {
+  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
+  return (
+    message.includes('object lock') ||
+    message.includes('objectlock') ||
+    message.includes('worm protected') ||
+    message.includes('retention') ||
+    message.includes('legal hold')
+  );
+}
+
+function empty_summary(): MutableResult {
+  return {
+    deleted_objects: 0,
+    deleted_manifests: 0,
+    retained_objects: 0,
+    retained_manifests: 0,
+    failed_objects: 0,
+    failed_manifests: 0,
+  };
+}

--- a/packages/core/src/services/deletion/sharepoint-deletion.service.ts
+++ b/packages/core/src/services/deletion/sharepoint-deletion.service.ts
@@ -5,6 +5,7 @@ import type {
   DeletionResult,
 } from '@wisecom/atlas-types';
 import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import { delete_scopes } from '@/services/deletion/shared/prefix-deleter';
 
 @injectable()
 export class SharePointDeletionService implements SharePointDeletionUseCase {
@@ -12,19 +13,22 @@ export class SharePointDeletionService implements SharePointDeletionUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
   ) {}
 
-  /** Deletes all backed-up SharePoint data for a single site. */
+  /**
+   * Deletes all backed-up SharePoint data for a single site.
+   *
+   * Staging is swept alongside the rest: a large-file upload interrupted before
+   * its canonical copy leaves the file content parked there, and the backup path
+   * only clears it opportunistically.
+   */
   async delete_site_data(tenant_id: string, site_id: string): Promise<DeletionResult> {
-    const ctx = await this._tenant_factory.create(tenant_id);
-    try {
-      return await delete_prefixes(ctx.storage, [
-        `sharepoint/manifests/${site_id}/`,
-        `sharepoint/data/${site_id}/`,
-        `sharepoint/index/${site_id}/`,
-        `sharepoint/_meta/${site_id}/`,
-      ]);
-    } finally {
-      ctx.destroy();
-    }
+    const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    return delete_scopes(storage, [
+      `sharepoint/manifests/${site_id}/`,
+      `sharepoint/data/${site_id}/`,
+      `sharepoint/index/${site_id}/`,
+      `sharepoint/_meta/${site_id}/`,
+      `sharepoint/staging/${site_id}/`,
+    ]);
   }
 
   /**
@@ -36,91 +40,7 @@ export class SharePointDeletionService implements SharePointDeletionUseCase {
     site_id: string,
     snapshot_id: string,
   ): Promise<DeletionResult> {
-    const ctx = await this._tenant_factory.create(tenant_id);
-    try {
-      const key = `sharepoint/manifests/${site_id}/${snapshot_id}.json`;
-      const summary = empty_deletion_summary();
-      await delete_single_key(ctx.storage, key, summary);
-      return { ...summary };
-    } finally {
-      ctx.destroy();
-    }
+    const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    return delete_scopes(storage, [`sharepoint/manifests/${site_id}/${snapshot_id}.json`]);
   }
-}
-
-interface DeletionStorage {
-  delete(key: string): Promise<void>;
-  list(prefix: string): Promise<string[]>;
-}
-
-type DeletionSummaryMutable = {
-  deleted_objects: number;
-  deleted_manifests: number;
-  retained_objects: number;
-  retained_manifests: number;
-  failed_objects: number;
-  failed_manifests: number;
-};
-
-/** Lists and deletes all keys under the provided prefixes. */
-async function delete_prefixes(
-  storage: DeletionStorage,
-  prefixes: string[],
-): Promise<DeletionResult> {
-  const summary = empty_deletion_summary();
-
-  for (const prefix of prefixes) {
-    const keys = await storage.list(prefix);
-    for (const key of keys) {
-      await delete_single_key(storage, key, summary);
-    }
-  }
-
-  return { ...summary };
-}
-
-async function delete_single_key(
-  storage: DeletionStorage,
-  key: string,
-  summary: DeletionSummaryMutable,
-): Promise<void> {
-  try {
-    await storage.delete(key);
-    increment_summary(summary, key, 'deleted');
-  } catch (err) {
-    const bucket = is_object_lock_delete_error(err) ? 'retained' : 'failed';
-    increment_summary(summary, key, bucket);
-  }
-}
-
-function increment_summary(
-  summary: DeletionSummaryMutable,
-  key: string,
-  outcome: 'deleted' | 'retained' | 'failed',
-): void {
-  const suffix = key.startsWith('sharepoint/manifests/') ? 'manifests' : 'objects';
-  const field = `${outcome}_${suffix}` as keyof DeletionSummaryMutable;
-  summary[field]++;
-}
-
-function is_object_lock_delete_error(err: unknown): boolean {
-  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
-  return (
-    message.includes('object lock') ||
-    message.includes('retention') ||
-    message.includes('worm protected') ||
-    message.includes('accessdenied') ||
-    message.includes('operationaborted')
-  );
-}
-
-function empty_deletion_summary(): DeletionSummaryMutable {
-  return {
-    deleted_objects: 0,
-    deleted_manifests: 0,
-    retained_objects: 0,
-    retained_manifests: 0,
-    failed_objects: 0,
-    failed_manifests: 0,
-  };
 }

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -104,7 +104,7 @@ describe('DeletionService', () => {
 
   describe('delete_mailbox_data', () => {
     it('deletes data, attachment, and manifest keys for a mailbox', async () => {
-      const list_fn = vi.mocked(mock_context.storage.list as ReturnType<typeof vi.fn>);
+      const list_fn = vi.mocked(mock_context.storage.list);
       list_fn
         .mockResolvedValueOnce(['manifests/user@test.com/snap-1.json'])
         .mockResolvedValueOnce(['data/user@test.com/aaa', 'data/user@test.com/bbb'])
@@ -160,7 +160,7 @@ describe('DeletionService', () => {
       vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
         make_manifest({ owner_id: 'u@t.com', snapshot_id: 'snap-42' }),
       );
-      vi.mocked(mock_context.storage.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      vi.mocked(mock_context.storage.list).mockResolvedValueOnce([
         'manifests/u@t.com/snap-42.json',
       ]);
 
@@ -186,10 +186,10 @@ describe('DeletionService', () => {
       vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
         make_manifest({ owner_id: 'u@t.com', snapshot_id: 'snap-42' }),
       );
-      vi.mocked(mock_context.storage.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      vi.mocked(mock_context.storage.list).mockResolvedValueOnce([
         'manifests/u@t.com/snap-42.json',
       ]);
-      vi.mocked(mock_context.storage.delete as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      vi.mocked(mock_context.storage.delete).mockRejectedValueOnce(
         new Error('AccessDenied: Object Lock retention in effect'),
       );
 
@@ -213,30 +213,59 @@ describe('DeletionService', () => {
   // ---------------------------------------------------------------------------
 
   describe('purge_tenant', () => {
-    it('deletes data, attachments, manifests, and meta keys', async () => {
-      const list_fn = vi.mocked(mock_context.storage.list as ReturnType<typeof vi.fn>);
+    it('sweeps every workload in the bucket, not a list of known prefixes', async () => {
+      const list_fn = vi.mocked(mock_context.storage.list);
       list_fn
-        .mockResolvedValueOnce(['manifests/u/snap-1.json'])
-        .mockResolvedValueOnce(['data/u/aaa', 'data/u/bbb'])
-        .mockResolvedValueOnce(['attachments/u/ccc'])
+        .mockResolvedValueOnce([
+          'manifests/u/snap-1.json',
+          'data/u/aaa',
+          'attachments/u/ccc',
+          'onedrive/data/u/blob',
+          'sharepoint/data/site/blob',
+          'identity-registry.json',
+        ])
         .mockResolvedValueOnce(['_meta/dek.enc']);
 
       const result = await service.purge_tenant('t');
 
-      expect(result.deleted_objects).toBe(4);
+      // Five workload objects from the sweep, plus the DEK from the second pass.
+      expect(result.deleted_objects).toBe(6);
       expect(result.deleted_manifests).toBe(1);
-      expect(result.retained_objects).toBe(0);
-      expect(result.failed_manifests).toBe(0);
-      expect(mock_context.storage.delete).toHaveBeenCalledTimes(5);
+      expect(mock_context.storage.delete).toHaveBeenCalledWith('onedrive/data/u/blob');
+      expect(mock_context.storage.delete).toHaveBeenCalledWith('sharepoint/data/site/blob');
+      expect(mock_context.storage.delete).toHaveBeenCalledWith('identity-registry.json');
     });
 
-    it('lists the four expected prefixes with manifests first', async () => {
+    it('holds the DEK back until the data it protects is gone', async () => {
+      vi.mocked(mock_context.storage.list).mockResolvedValueOnce(['onedrive/data/u/locked']);
+      vi.mocked(mock_context.storage.delete).mockRejectedValueOnce(
+        new Error('InvalidRequest: Object is WORM protected and cannot be overwritten'),
+      );
+
+      const result = await service.purge_tenant('t');
+
+      expect(result.retained_objects).toBe(1);
+      expect(mock_context.storage.delete).not.toHaveBeenCalledWith('_meta/dek.enc');
+      expect(mock_context.storage.list).not.toHaveBeenCalledWith('_meta/');
+    });
+
+    it('deletes the DEK last, once the sweep came back clean', async () => {
       await service.purge_tenant('t');
 
-      expect(mock_context.storage.list).toHaveBeenCalledWith('manifests/');
-      expect(mock_context.storage.list).toHaveBeenCalledWith('data/');
-      expect(mock_context.storage.list).toHaveBeenCalledWith('attachments/');
-      expect(mock_context.storage.list).toHaveBeenCalledWith('_meta/');
+      const scopes = vi.mocked(mock_context.storage.list).mock.calls.map(([scope]) => scope);
+      expect(scopes).toEqual(['', '_meta/']);
+    });
+
+    it('leaves the DEK out of the bucket-wide sweep', async () => {
+      vi.mocked(mock_context.storage.list)
+        .mockResolvedValueOnce(['data/u/aaa', '_meta/dek.enc'])
+        .mockResolvedValueOnce(['_meta/dek.enc']);
+
+      const result = await service.purge_tenant('t');
+
+      // One from the sweep, one from the DEK pass -- never twice from the sweep.
+      expect(result.deleted_objects).toBe(2);
+      expect(mock_context.storage.delete).toHaveBeenCalledTimes(2);
     });
 
     it('handles empty tenant bucket', async () => {

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -253,7 +253,29 @@ describe('DeletionService', () => {
       await service.purge_tenant('t');
 
       const scopes = vi.mocked(mock_context.storage.list).mock.calls.map(([scope]) => scope);
-      expect(scopes).toEqual(['', '_meta/']);
+      expect(scopes).toEqual(['', '_meta/dek.enc']);
+    });
+
+    it('erases the DEK-encrypted neighbours in _meta before the DEK itself', async () => {
+      // Replica markers and replication records share _meta/ with the key that
+      // decrypts them, and sort after it. Holding back the whole prefix would
+      // let a retained record outlive its key.
+      vi.mocked(mock_context.storage.list)
+        .mockResolvedValueOnce([
+          '_meta/dek.enc',
+          '_meta/replica.marker',
+          '_meta/replication/u/snap/target.json',
+        ])
+        .mockResolvedValueOnce(['_meta/dek.enc']);
+
+      await service.purge_tenant('t');
+
+      const order = vi.mocked(mock_context.storage.delete).mock.calls.map(([key]) => key);
+      expect(order).toEqual([
+        '_meta/replica.marker',
+        '_meta/replication/u/snap/target.json',
+        '_meta/dek.enc',
+      ]);
     });
 
     it('leaves the DEK out of the bucket-wide sweep', async () => {

--- a/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
+++ b/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The erasure primitive. These tests pin the two properties an erasure report
+ * has to get right: nothing recoverable is left behind, and the summary does not
+ * claim otherwise.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { delete_scopes, type DeletionStorage } from '@/services/deletion/shared/prefix-deleter';
+
+interface StubOptions {
+  versions?: { key: string; version_id: string; is_delete_marker?: boolean }[];
+  keys?: string[];
+}
+
+function make_storage({ versions = [], keys = [] }: StubOptions = {}): DeletionStorage {
+  return {
+    delete: vi.fn().mockResolvedValue(undefined),
+    delete_version: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue(keys),
+    list_versions: vi.fn().mockResolvedValue(versions),
+  };
+}
+
+describe('delete_scopes', () => {
+  it('deletes every version by id, not the visible key', async () => {
+    const storage = make_storage({
+      versions: [
+        { key: 'data/u/blob', version_id: 'v1' },
+        { key: 'data/u/blob', version_id: 'v2' },
+      ],
+    });
+
+    const result = await delete_scopes(storage, ['data/u/']);
+
+    // A plain delete here would leave both versions retrievable.
+    expect(storage.delete).not.toHaveBeenCalled();
+    expect(storage.delete_version).toHaveBeenCalledWith('data/u/blob', 'v1');
+    expect(storage.delete_version).toHaveBeenCalledWith('data/u/blob', 'v2');
+    expect(result.deleted_objects).toBe(2);
+  });
+
+  it('sweeps delete markers without counting them as erased data', async () => {
+    const storage = make_storage({
+      versions: [
+        { key: 'data/u/blob', version_id: 'v1' },
+        { key: 'data/u/blob', version_id: 'marker', is_delete_marker: true },
+      ],
+    });
+
+    const result = await delete_scopes(storage, ['data/u/']);
+
+    expect(storage.delete_version).toHaveBeenCalledWith('data/u/blob', 'marker');
+    expect(result.deleted_objects).toBe(1);
+  });
+
+  it('counts manifests separately at any depth', async () => {
+    const storage = make_storage({
+      versions: [
+        { key: 'manifests/u/snap.json', version_id: 'v1' },
+        { key: 'onedrive/manifests/u/snap.json', version_id: 'v1' },
+        { key: 'onedrive/data/u/blob', version_id: 'v1' },
+      ],
+    });
+
+    const result = await delete_scopes(storage, ['']);
+
+    expect(result.deleted_manifests).toBe(2);
+    expect(result.deleted_objects).toBe(1);
+  });
+
+  it('deletes manifests before the objects they reference', async () => {
+    const storage = make_storage({
+      versions: [
+        // Bucket order puts data first; an interrupted sweep must not leave a
+        // manifest pointing at blobs that are already gone.
+        { key: 'data/u/blob', version_id: 'v1' },
+        { key: 'manifests/u/snap.json', version_id: 'v1' },
+      ],
+    });
+
+    await delete_scopes(storage, ['']);
+
+    const order = vi.mocked(storage.delete_version).mock.calls.map(([key]) => key);
+    expect(order).toEqual(['manifests/u/snap.json', 'data/u/blob']);
+  });
+
+  it('falls back to visible keys when the backend lists no versions', async () => {
+    const storage = make_storage({ keys: ['data/u/blob'] });
+
+    const result = await delete_scopes(storage, ['data/u/']);
+
+    expect(storage.delete).toHaveBeenCalledWith('data/u/blob');
+    expect(result.deleted_objects).toBe(1);
+  });
+
+  it('skips the prefixes the caller holds back', async () => {
+    const storage = make_storage({
+      versions: [
+        { key: 'data/u/blob', version_id: 'v1' },
+        { key: '_meta/dek.enc', version_id: 'v1' },
+      ],
+    });
+
+    const result = await delete_scopes(storage, [''], ['_meta/']);
+
+    expect(storage.delete_version).toHaveBeenCalledTimes(1);
+    expect(storage.delete_version).not.toHaveBeenCalledWith('_meta/dek.enc', 'v1');
+    expect(result.deleted_objects).toBe(1);
+  });
+
+  describe('classifying a refused delete', () => {
+    async function delete_failing_with(err: Error) {
+      const storage = make_storage({ versions: [{ key: 'data/u/blob', version_id: 'v1' }] });
+      vi.mocked(storage.delete_version).mockRejectedValue(err);
+      return await delete_scopes(storage, ['data/u/']);
+    }
+
+    it('reports MinIO WORM protection as retained', async () => {
+      const result = await delete_failing_with(
+        new Error('InvalidRequest: Object is WORM protected and cannot be overwritten'),
+      );
+
+      expect(result.retained_objects).toBe(1);
+      expect(result.failed_objects).toBe(0);
+    });
+
+    it('reports AWS Object Lock protection as retained', async () => {
+      const result = await delete_failing_with(
+        new Error('AccessDenied: Access Denied because object protected by object lock'),
+      );
+
+      expect(result.retained_objects).toBe(1);
+      expect(result.failed_objects).toBe(0);
+    });
+
+    it('reports a bare permission denial as failed, never as retained', async () => {
+      // Retention expires and the data goes away on its own; an IAM gap does not.
+      // Filing this as "retained" would tell an operator erasure is on track.
+      const result = await delete_failing_with(new Error('AccessDenied: Access Denied'));
+
+      expect(result.failed_objects).toBe(1);
+      expect(result.retained_objects).toBe(0);
+    });
+
+    it('reports an unreachable backend as failed', async () => {
+      const result = await delete_failing_with(new Error('ECONNREFUSED 127.0.0.1:9002'));
+
+      expect(result.failed_objects).toBe(1);
+      expect(result.retained_objects).toBe(0);
+    });
+  });
+});

--- a/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
+++ b/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
@@ -83,6 +83,19 @@ describe('delete_scopes', () => {
     expect(order).toEqual(['manifests/u/snap.json', 'data/u/blob']);
   });
 
+  it('reports a delete marker it could not remove', async () => {
+    const storage = make_storage({
+      versions: [{ key: 'data/u/blob', version_id: 'marker', is_delete_marker: true }],
+    });
+    vi.mocked(storage.delete_version).mockRejectedValue(new Error('AccessDenied: Access Denied'));
+
+    const result = await delete_scopes(storage, ['data/u/']);
+
+    // Uncounted on success, but a marker that outlived the sweep is a survivor:
+    // a purge reading this summary as clean would drop the DEK.
+    expect(result.failed_objects).toBe(1);
+  });
+
   it('falls back to visible keys when the backend lists no versions', async () => {
     const storage = make_storage({ keys: ['data/u/blob'] });
 

--- a/packages/core/tests/unit/services/deletion/workload-deletion.test.ts
+++ b/packages/core/tests/unit/services/deletion/workload-deletion.test.ts
@@ -1,0 +1,123 @@
+/**
+ * OneDrive and SharePoint erasure. Both were deleting visible keys only, so in a
+ * versioned bucket they reported success while every byte stayed retrievable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';
+import { SharePointDeletionService } from '@/services/deletion/sharepoint-deletion.service';
+import { TENANT_CONTEXT_FACTORY_TOKEN, type TenantContextFactory } from '@wisecom/atlas-types';
+import type { DeletionStorage } from '@/services/deletion/shared/prefix-deleter';
+
+const OWNER = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+const SITE = 'contoso.sharepoint.com,site-guid,web-guid';
+
+function make_storage(): DeletionStorage {
+  return {
+    delete: vi.fn().mockResolvedValue(undefined),
+    delete_version: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('workload deletion', () => {
+  let storage: DeletionStorage;
+  let factory: TenantContextFactory;
+  let onedrive: OneDriveDeletionService;
+  let sharepoint: SharePointDeletionService;
+
+  beforeEach(() => {
+    storage = make_storage();
+    factory = {
+      create: vi.fn(),
+      create_storage_only: vi.fn().mockResolvedValue({ tenant_id: 't', storage }),
+    };
+
+    const container = new Container();
+    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
+    container.bind(OneDriveDeletionService).toSelf();
+    container.bind(SharePointDeletionService).toSelf();
+
+    onedrive = container.get(OneDriveDeletionService);
+    sharepoint = container.get(SharePointDeletionService);
+  });
+
+  describe('OneDriveDeletionService', () => {
+    it('erases versions rather than hiding them behind a delete marker', async () => {
+      vi.mocked(storage.list_versions).mockResolvedValueOnce([
+        { key: `onedrive/manifests/${OWNER}/snap.json`, version_id: 'v1', is_delete_marker: false },
+      ]);
+
+      const result = await onedrive.delete_owner_data('t', OWNER);
+
+      expect(storage.delete_version).toHaveBeenCalledWith(
+        `onedrive/manifests/${OWNER}/snap.json`,
+        'v1',
+      );
+      expect(storage.delete).not.toHaveBeenCalled();
+      expect(result.deleted_manifests).toBe(1);
+    });
+
+    it('sweeps staging, where an interrupted large-file upload parks content', async () => {
+      await onedrive.delete_owner_data('t', OWNER);
+
+      const scopes = vi.mocked(storage.list_versions).mock.calls.map(([scope]) => scope);
+      expect(scopes).toEqual([
+        `onedrive/manifests/${OWNER}/`,
+        `onedrive/data/${OWNER}/`,
+        `onedrive/index/${OWNER}/`,
+        `onedrive/_meta/${OWNER}/`,
+        `onedrive/staging/${OWNER}/`,
+      ]);
+    });
+
+    it('deletes a snapshot manifest version, leaving shared blobs alone', async () => {
+      vi.mocked(storage.list_versions).mockResolvedValueOnce([
+        { key: `onedrive/manifests/${OWNER}/snap.json`, version_id: 'v1', is_delete_marker: false },
+      ]);
+
+      const result = await onedrive.delete_snapshot('t', OWNER, 'snap');
+
+      expect(storage.list_versions).toHaveBeenCalledWith(`onedrive/manifests/${OWNER}/snap.json`);
+      expect(result.deleted_manifests).toBe(1);
+      expect(result.deleted_objects).toBe(0);
+    });
+
+    it('erases without the DEK, so a purged tenant can still be cleaned up', async () => {
+      await onedrive.delete_owner_data('t', OWNER);
+
+      expect(factory.create_storage_only).toHaveBeenCalledWith('t');
+      expect(factory.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SharePointDeletionService', () => {
+    it('erases versions rather than hiding them behind a delete marker', async () => {
+      vi.mocked(storage.list_versions).mockResolvedValueOnce([
+        { key: `sharepoint/data/${SITE}/blob`, version_id: 'v1', is_delete_marker: false },
+      ]);
+
+      const result = await sharepoint.delete_site_data('t', SITE);
+
+      expect(storage.delete_version).toHaveBeenCalledWith(`sharepoint/data/${SITE}/blob`, 'v1');
+      expect(storage.delete).not.toHaveBeenCalled();
+      expect(result.deleted_objects).toBe(1);
+    });
+
+    it('sweeps staging, where an interrupted large-file upload parks content', async () => {
+      await sharepoint.delete_site_data('t', SITE);
+
+      const scopes = vi.mocked(storage.list_versions).mock.calls.map(([scope]) => scope);
+      expect(scopes).toContain(`sharepoint/staging/${SITE}/`);
+    });
+
+    it('erases without the DEK, so a purged tenant can still be cleaned up', async () => {
+      await sharepoint.delete_site_data('t', SITE);
+
+      expect(factory.create_storage_only).toHaveBeenCalledWith('t');
+      expect(factory.create).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #28. Closes #27.

## Problem

Two halves of the same defect: Atlas reported erasure it had not performed.

**Deleting a key is not erasing it.** In a versioned bucket -- the prerequisite for Object Lock, so every immutability deployment has one -- `DeleteObject` without a version id writes a delete marker. The object leaves the listing, the deletion count goes up, and every byte stays one `GetObject?versionId=` away. Outlook deleted by version id. OneDrive and SharePoint carried their own copy of the same helper that did not.

**A purge that enumerates prefixes stops erasing whatever ships next.** `purge_tenant` swept `manifests/`, `data/`, `attachments/`, `_meta/` -- the complete list on the day it was written. OneDrive, SharePoint and the identity registry arrived later.

Both measured against the live tenant, versioning on, all three workloads backed up:

| | reported | actually left behind |
|---|---|---|
| `deleteOwnerData` (OneDrive) | 10 deleted | **14 versions**, readable, behind 10 delete markers |
| `purgeTenantData` | 65 deleted | **76 objects** across `onedrive/`, `sharepoint/`, `identity-registry.json` |

The purge is the worse of the two: it removed `_meta/dek.enc` on its way out, so the survivors can neither be restored nor be reported as erased.

## Fix

`delete_prefixes` / `delete_single_key` / `is_object_lock_delete_error` existed three times over and had already drifted apart. They are now one version-aware helper in `services/deletion/shared/prefix-deleter.ts`, and all three workloads route through it -- the divergence is not repairable while the code is copy-pasted.

Purge sweeps the bucket rather than a prefix list, so trees added later are covered without anyone remembering to add them, and holds the DEK back until the sweep reports nothing left.

Four things came along because they live in the lines being consolidated:

- **Delete markers are swept but never counted.** Removing one uncovers versions rather than destroying data.
- **Retention is recognised by name.** AWS says "Access Denied because object protected by object lock", MinIO says "Object is WORM protected" -- both name the mechanism. Any `AccessDenied` used to qualify, so a missing `s3:DeleteObjectVersion` permission was filed as "retained, deletable once retention expires". It is now a failure. A false alarm costs an investigation; a false all-clear costs the erasure.
- **Manifests still go first.** A bucket-wide sweep hits `data/` before `manifests/` alphabetically, which would have quietly broken the documented interrupt guarantee.
- **Staging is swept.** An interrupted large-file upload parks file content under `onedrive/staging/<owner>/`; the backup path only clears it opportunistically and owner deletion never looked there.

OneDrive and SharePoint deletion also stop opening a full tenant context -- erasure needs no key material, and this lets a purged tenant still be cleaned up.

## Evidence

Same script, same live tenant, before and after:

```
ISSUE 28  before fix   reported 10 deleted -> 14 versions + 10 markers survive
          after  fix   reported 14 deleted -> 0 versions, 0 markers
ISSUE 27  before fix   reported 65 deleted -> 76 objects left, DEK gone
          after  fix   reported 127 deleted -> bucket empty
```

Both issues' acceptance criteria are "zero objects and zero noncurrent versions", met exactly.

The retention path was exercised live too, against a real Object Lock bucket with one object under COMPLIANCE retention:

```
reported     : {"deleted_objects":1,"retained_objects":1,"failed_objects":0,...}
surviving    : ["_meta/dek.enc","data/u/held"]
DEK          : PRESERVED -- data stays recoverable
```

The classifier strings are not guesses: MinIO's refusal was captured from the running backend (`InvalidRequest` / "Object is WORM protected and cannot be overwritten" -- notably *not* `AccessDenied`). Version-id deletes were also confirmed against a non-versioned bucket, which returns `"null"` and deletes correctly, so routing OneDrive and SharePoint through the version-aware path is safe on both bucket types.

11 new tests cover version deletion, marker sweeping, manifest ordering, the skip list, and all four classification outcomes. OneDrive and SharePoint deletion had no tests at all and now do. Full suite 790, lint, format, docs build.

## Docs

`security.md` gains an **Erasure** section -- versions are the data, why the purge sweeps, and the retained/failed distinction. `cli.md`, `cli-recovery.md`, `sdk.md`, `onedrive-backup.md` and `sharepoint-backup.md` all carried the weaker claim and now match.

## Not in scope

#38 overlaps here and its triplication and `AccessDenied` items are fixed by this PR. Its remaining two -- the dead conditional-copy branch in the large-file pipeline, and `owner_id` normalisation -- are untouched and #38 stays open for them.

Worth knowing while reading this: OneDrive and SharePoint storage keys use the Entra **object ID**, so `deleteOwnerData('user@company.com')` matches nothing and returns all zeros. That is not a regression and not this fix, but a GDPR erasure call that no-ops while reporting success is a sharp edge; the SDK docs now state which identifier the method takes. Worth its own issue on the SDK consistency track (#45).
