### PR TITLE
fix(storage): fold identifier case once, and drop the unreachable copy branch

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -60,6 +60,14 @@ If `--owner` contains `@`, the CLI resolves it via `GraphUserIdentityResolver`: 
 
 Mailbox backup currently keys `data/` and `manifests/` by the mailbox identifier supplied to sync (often the primary SMTP address). OneDrive is intentionally keyed by object ID after resolution so operators should not assume the same string appears in both trees for a given person.
 
+### Identifier case
+
+Object IDs, mailbox addresses, and SharePoint site IDs are all case-insensitive to Microsoft Graph and case-sensitive to S3, so Atlas lowercases them before they become key segments. Two spellings of one identifier therefore address one tree.
+
+This matters most for deletion. Before 2.1.0-beta, `deleteOwnerData` given an uppercase object ID swept an empty prefix, reported the objects it deleted there, and left the real data untouched -- an erasure that reported success while every byte stayed retrievable. Graph returns these identifiers lowercase, so the gap only opened for callers supplying their own: an operator pasting an object ID from a portal, or an SDK embedder holding one in application state.
+
+Graph **item** IDs (`file_id`, `item_id`) are genuinely case-sensitive and are never folded. `--file-filter` accepts them exactly as a listing prints them, and compares case-insensitively so a retyped ID still matches.
+
 ## SDK Usage
 
 The SDK exposes OneDrive backup, restore, verification, deletion, status, and replication as programmatic methods on `atlas.onedrive`:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -368,6 +368,8 @@ Unlike Outlook (which stamps a per-object `retain_until` on each write), OneDriv
 | `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
 | `-t, --tenant <id>`        | Override tenant ID from config                                           |
 
+Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree -- earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
+
 **`atlas onedrive list-snapshots`**
 
 | Option              | Description                              |

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -117,6 +117,20 @@ const mailboxes = await atlas.outlook.listAvailableMailboxes();
 const shared = mailboxes.filter((mb) => mb.mailbox_purpose === 'shared');
 ```
 
+### Identifier case
+
+Every method taking a mailbox address, an Entra object ID, or a SharePoint site ID lowercases it before it becomes a storage key segment, so two spellings of one identifier address one tree.
+
+The SDK is where this used to bite. Graph hands back these identifiers lowercase, so the CLI never saw the problem; an embedder holding an object ID in application state or reading one from a portal could. Two spellings meant two prefixes -- the same drive backed up twice, and worse:
+
+```typescript
+// Before 2.1.0-beta: swept an empty prefix, reported what it deleted there,
+// and left the real data behind -- a successful-looking erasure of nothing.
+await atlas.onedrive.deleteOwnerData('75A21B57-4D82-4F42-9CCC-7C231C30F78C');
+```
+
+Graph **item** IDs (`file_id`, `item_id`) are case-sensitive and never folded. `file_filter` compares them case-insensitively, so an ID copied from `listFileVersions()` matches whatever case you send it in.
+
 ## Save Options
 
 `atlas.outlook.save` and `atlas.outlook.saveMailbox` accept the following options:

--- a/packages/core/src/services/catalog/catalog.service.ts
+++ b/packages/core/src/services/catalog/catalog.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
@@ -29,7 +30,7 @@ export class CatalogService implements CatalogUseCase {
 
   /** Returns every manifest for a given mailbox owner, sorted newest-first. */
   async list_snapshots(tenant_id: string, owner_id: string): Promise<Manifest[]> {
-    owner_id = owner_id.toLowerCase();
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const all = await this._manifests.list_all_manifests(ctx);

--- a/packages/core/src/services/deletion/deletion.service.ts
+++ b/packages/core/src/services/deletion/deletion.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
@@ -33,7 +34,7 @@ export class DeletionService implements DeletionUseCase {
    * objects (harmless) rather than manifests referencing deleted objects.
    */
   async delete_mailbox_data(tenant_id: string, owner_id: string): Promise<DeletionResult> {
-    owner_id = owner_id.toLowerCase();
+    owner_id = normalize_owner_id(owner_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     return delete_scopes(storage, [
       `manifests/${owner_id}/`,

--- a/packages/core/src/services/deletion/onedrive-deletion.service.ts
+++ b/packages/core/src/services/deletion/onedrive-deletion.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   OneDriveDeletionUseCase,
@@ -21,6 +22,7 @@ export class OneDriveDeletionService implements OneDriveDeletionUseCase {
    * only clears it opportunistically.
    */
   async delete_owner_data(tenant_id: string, owner_id: string): Promise<DeletionResult> {
+    owner_id = normalize_owner_id(owner_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     return delete_scopes(storage, [
       `onedrive/manifests/${owner_id}/`,
@@ -40,6 +42,7 @@ export class OneDriveDeletionService implements OneDriveDeletionUseCase {
     owner_id: string,
     snapshot_id: string,
   ): Promise<DeletionResult> {
+    owner_id = normalize_owner_id(owner_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     return delete_scopes(storage, [`onedrive/manifests/${owner_id}/${snapshot_id}.json`]);
   }

--- a/packages/core/src/services/deletion/sharepoint-deletion.service.ts
+++ b/packages/core/src/services/deletion/sharepoint-deletion.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointDeletionUseCase,
@@ -21,6 +22,7 @@ export class SharePointDeletionService implements SharePointDeletionUseCase {
    * only clears it opportunistically.
    */
   async delete_site_data(tenant_id: string, site_id: string): Promise<DeletionResult> {
+    site_id = normalize_owner_id(site_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     return delete_scopes(storage, [
       `sharepoint/manifests/${site_id}/`,
@@ -40,6 +42,7 @@ export class SharePointDeletionService implements SharePointDeletionUseCase {
     site_id: string,
     snapshot_id: string,
   ): Promise<DeletionResult> {
+    site_id = normalize_owner_id(site_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     return delete_scopes(storage, [`sharepoint/manifests/${site_id}/${snapshot_id}.json`]);
   }

--- a/packages/core/src/services/replication/onedrive-replication.service.ts
+++ b/packages/core/src/services/replication/onedrive-replication.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@wisecom/atlas-types';
 import type { OneDriveManifestRepository, OneDriveSnapshotManifest } from '@wisecom/atlas-types';
@@ -45,6 +46,7 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     snapshot_id: string,
     targets: StorageTarget[],
   ): Promise<ReplicationResult[]> {
+    owner_id = normalize_owner_id(owner_id);
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this.require_manifest(source_ctx, owner_id, snapshot_id);
@@ -78,6 +80,7 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     owner_id: string,
     targets: StorageTarget[],
   ): Promise<ReplicationResult[]> {
+    owner_id = normalize_owner_id(owner_id);
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifests = await this._od_manifests.list_snapshots_by_owner(source_ctx, owner_id);
@@ -121,6 +124,7 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     snapshot_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
+    owner_id = normalize_owner_id(owner_id);
     await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
@@ -154,6 +158,7 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     owner_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
+    owner_id = normalize_owner_id(owner_id);
     await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
@@ -66,6 +67,7 @@ export class ReplicationService implements ReplicationUseCase {
     owner_id: string,
     targets: StorageTarget[],
   ): Promise<ReplicationResult[]> {
+    owner_id = normalize_owner_id(owner_id);
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifests = await this.list_mailbox_manifests(source_ctx, owner_id);
@@ -127,6 +129,7 @@ export class ReplicationService implements ReplicationUseCase {
     owner_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
+    owner_id = normalize_owner_id(owner_id);
     await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);

--- a/packages/core/src/services/replication/sharepoint-replication.service.ts
+++ b/packages/core/src/services/replication/sharepoint-replication.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@wisecom/atlas-types';
 import type {
@@ -50,6 +51,7 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
     snapshot_id: string,
     targets: StorageTarget[],
   ): Promise<ReplicationResult[]> {
+    site_id = normalize_owner_id(site_id);
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this.require_sp_manifest(source_ctx, site_id, snapshot_id);
@@ -83,6 +85,7 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
     site_id: string,
     targets: StorageTarget[],
   ): Promise<ReplicationResult[]> {
+    site_id = normalize_owner_id(site_id);
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifests = await this._sp_manifests.list_snapshots_by_site(source_ctx, site_id);
@@ -126,6 +129,7 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
     snapshot_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
+    site_id = normalize_owner_id(site_id);
     await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
@@ -159,6 +163,7 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
     site_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
+    site_id = normalize_owner_id(site_id);
     await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);

--- a/packages/core/src/services/shared/identifier-normalization.ts
+++ b/packages/core/src/services/shared/identifier-normalization.ts
@@ -1,0 +1,21 @@
+/**
+ * One rule for the identifiers that become storage key segments.
+ *
+ * A mailbox address, an Entra object ID, and a SharePoint site ID are all
+ * case-insensitive to Microsoft but case-sensitive to S3. Passing two spellings
+ * of one identifier used to write two prefixes: the same drive backed up twice,
+ * and a delete that reported success against whichever spelling it was handed
+ * while the other survived (issue #38).
+ *
+ * Graph returns these lowercase already, so this only bites callers who supply
+ * their own -- an operator pasting an object ID from a portal, or an SDK
+ * embedder holding it in application state.
+ *
+ * Applies ONLY to owner-style identifiers. Graph item IDs (`file_id`,
+ * `item_id`) are genuinely case-sensitive and must never pass through here.
+ */
+
+/** Normalizes a mailbox, owner, or site identifier used as a storage key segment. */
+export function normalize_owner_id(value: string): string {
+  return value.toLowerCase();
+}

--- a/packages/core/src/services/stats/stats.service.ts
+++ b/packages/core/src/services/stats/stats.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type {
@@ -76,7 +77,7 @@ export class StatsService implements StatsUseCase {
 
   /** Loads manifests for a single mailbox and computes its statistics. */
   async get_mailbox_stats(tenant_id: string, owner_id: string): Promise<MailboxStats> {
-    owner_id = owner_id.toLowerCase();
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const all = await this._manifests.list_all_manifests(ctx);

--- a/packages/core/tests/unit/services/deletion/identifier-case.test.ts
+++ b/packages/core/tests/unit/services/deletion/identifier-case.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Issue #38: `deleteOwnerData` given the uppercase spelling of an owner reported
+ * success and left the lowercase tree behind -- an erasure that erased nothing.
+ */
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import 'reflect-metadata';
+import { Container } from 'inversify';
+import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import type { TenantContextFactory } from '@wisecom/atlas-types';
+import { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';
+import { SharePointDeletionService } from '@/services/deletion/sharepoint-deletion.service';
+
+const LOWER = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+const UPPER = LOWER.toUpperCase();
+const SITE_LOWER = 'contoso.sharepoint.com,site-guid,web-guid';
+
+/** The slice of storage a deletion sweep touches, with calls recorded. */
+interface RecordingStorage {
+  delete: Mock;
+  delete_version: Mock;
+  list: Mock;
+  list_versions: Mock;
+}
+
+function make_storage(): RecordingStorage {
+  return {
+    delete: vi.fn().mockResolvedValue(undefined),
+    delete_version: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('deletion prefixes ignore identifier case', () => {
+  let storage: RecordingStorage;
+  let container: Container;
+
+  beforeEach(() => {
+    storage = make_storage();
+    const factory = {
+      create: vi.fn(),
+      create_storage_only: vi.fn().mockResolvedValue({ storage }),
+    } as unknown as TenantContextFactory;
+
+    container = new Container();
+    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
+    container.bind(OneDriveDeletionService).toSelf();
+    container.bind(SharePointDeletionService).toSelf();
+  });
+
+  const swept = (): string[] => storage.list_versions.mock.calls.map(([scope]) => scope as string);
+
+  it('sweeps the lowercase owner tree when handed the uppercase spelling', async () => {
+    await container.get(OneDriveDeletionService).delete_owner_data('t', UPPER);
+
+    expect(swept()).toEqual([
+      `onedrive/manifests/${LOWER}/`,
+      `onedrive/data/${LOWER}/`,
+      `onedrive/index/${LOWER}/`,
+      `onedrive/_meta/${LOWER}/`,
+      `onedrive/staging/${LOWER}/`,
+    ]);
+    expect(swept().some((scope) => scope.includes(UPPER))).toBe(false);
+  });
+
+  it('sweeps the lowercase site tree when handed a mixed-case site id', async () => {
+    await container
+      .get(SharePointDeletionService)
+      .delete_site_data('t', 'Contoso.SharePoint.com,SITE-GUID,WEB-GUID');
+
+    expect(swept()[0]).toBe(`sharepoint/manifests/${SITE_LOWER}/`);
+  });
+
+  it('addresses one snapshot manifest regardless of spelling', async () => {
+    await container.get(OneDriveDeletionService).delete_snapshot('t', UPPER, 'snap-1');
+
+    expect(swept()).toEqual([`onedrive/manifests/${LOWER}/snap-1.json`]);
+  });
+});

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -52,6 +53,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
     owner_id: string,
     options: OneDriveBackupOptions = {},
   ): Promise<OneDriveBackupResult> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     if (options.object_lock_request?.retention_days) {
       // Bucket default retention: every new object version (files, versions,

--- a/packages/onedrive/src/services/onedrive-catalog.service.ts
+++ b/packages/onedrive/src/services/onedrive-catalog.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   OneDriveCatalogUseCase,
@@ -30,6 +31,7 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
     tenant_id: string,
     owner_id: string,
   ): Promise<OneDriveSnapshotManifest[]> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       return this._manifests.list_snapshots_by_owner(ctx, owner_id);
@@ -44,6 +46,7 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
     owner_id: string,
     file_ref: string,
   ): Promise<OneDriveFileVersionRecord[]> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const file_id = await this.resolve_file_id(ctx, owner_id, file_ref);

--- a/packages/onedrive/src/services/onedrive-large-file-pipeline.ts
+++ b/packages/onedrive/src/services/onedrive-large-file-pipeline.ts
@@ -106,14 +106,14 @@ export async function process_large_file(
 
   await handle.complete(completed_parts);
 
+  // ponytail: the exists() check above races a concurrent writer, and the loser
+  // overwrites with identical bytes -- canonical_key IS the SHA-256 of the
+  // content, so the duplicate is benign. Conditional copy would make it atomic,
+  // but MinIO ignores IfNoneMatch on CopyObject, so guarding it here would only
+  // look safe. Revisit if a backend honours it.
   try {
     await ctx.storage.copy(staging_key, canonical_key, undefined, object_lock_policy);
   } catch (err) {
-    if (is_precondition_failed(err)) {
-      logger.info(`Concurrent writer stored ${item.file_name} first — dedup`);
-      await ctx.storage.delete(staging_key).catch(() => {});
-      return { checksum, storage_key: canonical_key, stored: false, deduplicated: true };
-    }
     logger.warn(`Copy staging->canonical failed, cleaning up: ${err}`);
     await ctx.storage.delete(staging_key).catch(() => {});
     throw err;
@@ -216,14 +216,6 @@ async function safe_abort(
     logger.warn(`Multipart abort failed, cleaning up orphaned parts: ${err}`);
     await ctx.storage.abort_incomplete_uploads(staging_prefix).catch(() => {});
   }
-}
-
-function is_precondition_failed(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const code = (err as Record<string, unknown>).Code ?? (err as Record<string, unknown>).code;
-  if (code === 'PreconditionFailed') return true;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('PreconditionFailed') || message.includes('412');
 }
 
 function format_bytes(bytes: number): string {

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -47,6 +48,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
     owner_id: string,
     options: OneDriveRestoreOptions,
   ): Promise<OneDriveRestoreResult> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
@@ -179,7 +181,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
     const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
     return entries.filter(
       (e) =>
-        filter_set.has(e.file_id) ||
+        filter_set.has(e.file_id.toLowerCase()) ||
         filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
     );
   }

--- a/packages/onedrive/src/services/onedrive-save.service.ts
+++ b/packages/onedrive/src/services/onedrive-save.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -39,6 +40,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
     owner_id: string,
     options: FileSaveOptions,
   ): Promise<FileSaveResult> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
@@ -110,7 +112,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
     const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
     return entries.filter(
       (e) =>
-        filter_set.has(e.file_id) ||
+        filter_set.has(e.file_id.toLowerCase()) ||
         filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
     );
   }

--- a/packages/onedrive/src/services/onedrive-storage-keys.ts
+++ b/packages/onedrive/src/services/onedrive-storage-keys.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 
 /** Prefix for content-addressed OneDrive file blobs. */
 export const ONEDRIVE_DATA_PREFIX = 'onedrive/data';
@@ -15,6 +16,16 @@ export const ONEDRIVE_INDEX_PREFIX = 'onedrive/index';
 /** Prefix for OneDrive sync metadata (e.g. delta cursors). */
 export const ONEDRIVE_META_PREFIX = 'onedrive/_meta';
 
+/**
+ * Validates an owner segment and returns it in the one case every path agrees
+ * on. Services normalize on entry; this is the backstop that keeps a path which
+ * forgets from writing a second prefix for the same owner (issue #38).
+ */
+function owner_segment(owner_id: string): string {
+  validate_key_segment(owner_id);
+  return normalize_owner_id(owner_id);
+}
+
 /** Ensures a single path segment is safe for S3-style keys (no traversal or extra slashes). */
 export function validate_key_segment(value: string): void {
   if (value === '' || value === '.' || value === '..') {
@@ -30,22 +41,22 @@ export function validate_key_segment(value: string): void {
 
 /** Builds the content-addressed key for a stored file blob. */
 export function onedrive_data_key(owner_id: string, checksum: string): string {
-  validate_key_segment(owner_id);
+  const owner = owner_segment(owner_id);
   validate_key_segment(checksum);
-  return `${ONEDRIVE_DATA_PREFIX}/${owner_id}/${checksum}`;
+  return `${ONEDRIVE_DATA_PREFIX}/${owner}/${checksum}`;
 }
 
 /** Builds the key for a snapshot manifest. */
 export function onedrive_manifest_key(owner_id: string, snapshot_id: string): string {
-  validate_key_segment(owner_id);
+  const owner = owner_segment(owner_id);
   validate_key_segment(snapshot_id);
-  return `${ONEDRIVE_MANIFEST_PREFIX}/${owner_id}/${snapshot_id}.json`;
+  return `${ONEDRIVE_MANIFEST_PREFIX}/${owner}/${snapshot_id}.json`;
 }
 
 /** Builds the prefix for listing all manifests of an owner. */
 export function onedrive_manifest_prefix(owner_id: string): string {
-  validate_key_segment(owner_id);
-  return `${ONEDRIVE_MANIFEST_PREFIX}/${owner_id}/`;
+  const owner = owner_segment(owner_id);
+  return `${ONEDRIVE_MANIFEST_PREFIX}/${owner}/`;
 }
 
 /** Returns the root prefix for all OneDrive manifests. */
@@ -55,15 +66,15 @@ export function onedrive_manifest_root_prefix(): string {
 
 /** Builds the key for a file's version index. */
 export function onedrive_index_key(owner_id: string, file_id: string): string {
-  validate_key_segment(owner_id);
+  const owner = owner_segment(owner_id);
   validate_key_segment(file_id);
-  return `${ONEDRIVE_INDEX_PREFIX}/${owner_id}/files/${file_id}.json`;
+  return `${ONEDRIVE_INDEX_PREFIX}/${owner}/files/${file_id}.json`;
 }
 
 /** Builds the prefix for listing all file indexes of an owner. */
 export function onedrive_index_prefix(owner_id: string): string {
-  validate_key_segment(owner_id);
-  return `${ONEDRIVE_INDEX_PREFIX}/${owner_id}/files/`;
+  const owner = owner_segment(owner_id);
+  return `${ONEDRIVE_INDEX_PREFIX}/${owner}/files/`;
 }
 
 /** Returns the root prefix for all OneDrive file indexes. */
@@ -73,20 +84,20 @@ export function onedrive_index_root_prefix(): string {
 
 /** Builds a unique staging key for multipart upload of a file. */
 export function onedrive_staging_key(owner_id: string, item_id: string): string {
-  validate_key_segment(owner_id);
+  const owner = owner_segment(owner_id);
   validate_key_segment(item_id);
   const suffix = randomBytes(4).toString('hex');
-  return `${ONEDRIVE_STAGING_PREFIX}/${owner_id}/${item_id}-${suffix}`;
+  return `${ONEDRIVE_STAGING_PREFIX}/${owner}/${item_id}-${suffix}`;
 }
 
 /** Builds the prefix for listing staging objects. */
 export function onedrive_staging_prefix(owner_id: string): string {
-  validate_key_segment(owner_id);
-  return `${ONEDRIVE_STAGING_PREFIX}/${owner_id}/`;
+  const owner = owner_segment(owner_id);
+  return `${ONEDRIVE_STAGING_PREFIX}/${owner}/`;
 }
 
 /** Builds the key for the delta cursor state. */
 export function onedrive_delta_cursor_key(owner_id: string): string {
-  validate_key_segment(owner_id);
-  return `${ONEDRIVE_META_PREFIX}/${owner_id}/delta.json`;
+  const owner = owner_segment(owner_id);
+  return `${ONEDRIVE_META_PREFIX}/${owner}/delta.json`;
 }

--- a/packages/onedrive/src/services/onedrive-verification.service.ts
+++ b/packages/onedrive/src/services/onedrive-verification.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -34,6 +35,7 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
     owner_id: string,
     snapshot_id: string,
   ): Promise<OneDriveVerificationResult> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, snapshot_id);

--- a/packages/onedrive/src/services/status/onedrive-status.service.ts
+++ b/packages/onedrive/src/services/status/onedrive-status.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   TenantContextFactory,
@@ -30,7 +31,7 @@ export class OneDriveStatusService implements OneDriveStatusUseCase {
 
   /** Peeks at Graph delta state to report whether a OneDrive backup is current. */
   async check_onedrive_status(tenant_id: string, owner_id: string): Promise<OneDriveStatusResult> {
-    owner_id = owner_id.toLowerCase();
+    owner_id = normalize_owner_id(owner_id);
 
     const ctx = await this._tenant_factory.create(tenant_id);
     try {

--- a/packages/onedrive/tests/unit/services/onedrive-file-filter.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-file-filter.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `--file-filter` by item ID never matched: the filter was lowercased and Graph
+ * drive item IDs carry uppercase (`01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3`).
+ * SharePoint restore was fixed in #75; restore and save on both workloads
+ * carried the same defect. Live proof: the same save command returned 0 files
+ * before and 1 after.
+ */
+import { describe, it, expect } from 'vitest';
+import 'reflect-metadata';
+import { OneDriveRestoreService } from '@/services/onedrive-restore.service';
+import { OneDriveSaveService } from '@/services/onedrive-save.service';
+import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
+
+const ITEM_ID = '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3';
+
+const ENTRY = {
+  file_id: ITEM_ID,
+  file_name: 'Report.docx',
+  parent_path: '/Documents',
+  change_type: 'created',
+  storage_key: 'onedrive/data/o/abc',
+} as OneDriveManifestEntry;
+
+interface Filterable {
+  filter_entries(
+    entries: readonly OneDriveManifestEntry[],
+    file_filter?: string[],
+  ): OneDriveManifestEntry[];
+}
+
+/** `filter_entries` is private; both services must answer the same way. */
+const services: [string, Filterable][] = [
+  ['restore', OneDriveRestoreService.prototype as unknown as Filterable],
+  ['save', OneDriveSaveService.prototype as unknown as Filterable],
+];
+
+describe.each(services)('%s file_filter', (_name, service) => {
+  it('matches an item id pasted verbatim from a listing', () => {
+    expect(service.filter_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
+  });
+
+  it('matches an item id typed in any case', () => {
+    expect(service.filter_entries([ENTRY], [ITEM_ID.toLowerCase()])).toHaveLength(1);
+  });
+
+  it('still matches by path', () => {
+    expect(service.filter_entries([ENTRY], ['/documents/report.docx'])).toHaveLength(1);
+  });
+
+  it('excludes what was not asked for', () => {
+    expect(service.filter_entries([ENTRY], ['/Documents/Other.docx'])).toHaveLength(0);
+  });
+
+  it('returns everything when no filter is given', () => {
+    expect(service.filter_entries([ENTRY], [])).toHaveLength(1);
+  });
+});

--- a/packages/onedrive/tests/unit/services/onedrive-storage-keys.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-storage-keys.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Issue #38: two spellings of one owner used to write two key prefixes -- the
+ * same drive stored twice, and a delete that erased whichever spelling it was
+ * handed while the other survived.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  onedrive_data_key,
+  onedrive_manifest_key,
+  onedrive_manifest_prefix,
+  onedrive_index_key,
+  onedrive_index_prefix,
+  onedrive_staging_key,
+  onedrive_staging_prefix,
+  onedrive_delta_cursor_key,
+} from '@/services/onedrive-storage-keys';
+
+const LOWER = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+const UPPER = LOWER.toUpperCase();
+
+describe('owner segment normalization', () => {
+  it('builds one key for either spelling of the owner', () => {
+    expect(onedrive_data_key(UPPER, 'abc')).toBe(onedrive_data_key(LOWER, 'abc'));
+    expect(onedrive_manifest_key(UPPER, 'snap-1')).toBe(onedrive_manifest_key(LOWER, 'snap-1'));
+    expect(onedrive_manifest_prefix(UPPER)).toBe(onedrive_manifest_prefix(LOWER));
+    expect(onedrive_index_key(UPPER, 'f1')).toBe(onedrive_index_key(LOWER, 'f1'));
+    expect(onedrive_index_prefix(UPPER)).toBe(onedrive_index_prefix(LOWER));
+    expect(onedrive_staging_prefix(UPPER)).toBe(onedrive_staging_prefix(LOWER));
+    expect(onedrive_delta_cursor_key(UPPER)).toBe(onedrive_delta_cursor_key(LOWER));
+  });
+
+  it('leaves the owner in the case the deletion prefixes expect', () => {
+    expect(onedrive_data_key(UPPER, 'abc')).toBe(`onedrive/data/${LOWER}/abc`);
+  });
+
+  it('preserves the case of a Graph item id, which is case-sensitive', () => {
+    // A drive item id like 01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3 must survive intact.
+    const item_id = '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3';
+    expect(onedrive_staging_key(UPPER, item_id)).toContain(`/${item_id}-`);
+    expect(onedrive_index_key(UPPER, item_id)).toContain(`/${item_id}.json`);
+  });
+
+  it('still rejects a traversal segment', () => {
+    expect(() => onedrive_data_key('..', 'abc')).toThrow(/Invalid storage key segment/);
+    expect(() => onedrive_data_key('a/b', 'abc')).toThrow(/Invalid storage key segment/);
+  });
+});

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
@@ -55,7 +56,7 @@ export class MailboxSyncService implements BackupUseCase {
     owner_id: string,
     options: SyncOptions = {},
   ): Promise<SyncResult> {
-    owner_id = owner_id.toLowerCase();
+    owner_id = normalize_owner_id(owner_id);
     await assert_mailbox_exists(this._connector, tenant_id, owner_id);
     const mailbox_purpose = await this._connector.get_mailbox_purpose?.(tenant_id, owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);

--- a/packages/outlook/src/services/status/mailbox-status.service.ts
+++ b/packages/outlook/src/services/status/mailbox-status.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
@@ -21,7 +22,7 @@ export class MailboxStatusService implements StatusUseCase {
 
   /** Peeks at Graph delta state to report whether a mailbox backup is current. */
   async check_mailbox_status(tenant_id: string, owner_id: string): Promise<MailboxStatusResult> {
-    owner_id = owner_id.toLowerCase();
+    owner_id = normalize_owner_id(owner_id);
     await assert_mailbox_exists(this._connector, tenant_id, owner_id);
 
     const ctx = await this._tenant_factory.create(tenant_id);

--- a/packages/sharepoint/src/services/sharepoint-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -58,6 +59,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     site_id: string,
     options: SharePointBackupOptions = {},
   ): Promise<SharePointBackupResult> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     if (options.object_lock_request?.retention_days) {
       // Bucket default retention: every new object version (files, versions,

--- a/packages/sharepoint/src/services/sharepoint-catalog.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-catalog.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointCatalogUseCase,
@@ -30,6 +31,7 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
     tenant_id: string,
     site_id: string,
   ): Promise<SharePointSnapshotManifest[]> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       return await this._manifests.list_snapshots_by_site(ctx, site_id);
@@ -44,6 +46,7 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
     site_id: string,
     file_ref: string,
   ): Promise<SharePointFileVersionRecord[]> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const file_id = await this.resolve_file_id(ctx, site_id, file_ref);

--- a/packages/sharepoint/src/services/sharepoint-large-file-pipeline.ts
+++ b/packages/sharepoint/src/services/sharepoint-large-file-pipeline.ts
@@ -76,14 +76,14 @@ export async function process_large_file(
 
   await handle.complete(completed_parts);
 
+  // ponytail: the exists() check above races a concurrent writer, and the loser
+  // overwrites with identical bytes -- canonical_key IS the SHA-256 of the
+  // content, so the duplicate is benign. Conditional copy would make it atomic,
+  // but MinIO ignores IfNoneMatch on CopyObject, so guarding it here would only
+  // look safe. Revisit if a backend honours it.
   try {
     await ctx.storage.copy(staging_key, canonical_key, undefined, object_lock_policy);
   } catch (err) {
-    if (is_precondition_failed(err)) {
-      logger.info(`Concurrent writer stored ${item.file_name} first — dedup`);
-      await ctx.storage.delete(staging_key).catch(() => {});
-      return { checksum, storage_key: canonical_key, stored: false, deduplicated: true };
-    }
     logger.warn(`Copy staging->canonical failed, cleaning up: ${err}`);
     await ctx.storage.delete(staging_key).catch(() => {});
     throw err;
@@ -187,14 +187,6 @@ async function stream_encrypt_upload(
     );
     throw err;
   }
-}
-
-function is_precondition_failed(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const code = (err as Record<string, unknown>).Code ?? (err as Record<string, unknown>).code;
-  if (code === 'PreconditionFailed') return true;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('PreconditionFailed') || message.includes('412');
 }
 
 function format_bytes(bytes: number): string {

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointDocumentLibrary,
@@ -51,6 +52,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     site_id: string,
     options: SharePointRestoreOptions,
   ): Promise<SharePointRestoreResult> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);

--- a/packages/sharepoint/src/services/sharepoint-save.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-save.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -39,6 +40,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
     site_id: string,
     options: FileSaveOptions,
   ): Promise<FileSaveResult> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
@@ -110,7 +112,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
     const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
     return entries.filter(
       (e) =>
-        filter_set.has(e.file_id) ||
+        filter_set.has(e.file_id.toLowerCase()) ||
         filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
     );
   }

--- a/packages/sharepoint/src/services/sharepoint-storage-keys.ts
+++ b/packages/sharepoint/src/services/sharepoint-storage-keys.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 
 /** Prefix for content-addressed SharePoint file blobs. */
 export const SHAREPOINT_DATA_PREFIX = 'sharepoint/data';
@@ -15,6 +16,16 @@ export const SHAREPOINT_INDEX_PREFIX = 'sharepoint/index';
 /** Prefix for SharePoint sync metadata (e.g. delta cursors). */
 export const SHAREPOINT_META_PREFIX = 'sharepoint/_meta';
 
+/**
+ * Validates a site segment and returns it in the one case every path agrees on.
+ * Services normalize on entry; this is the backstop that keeps a path which
+ * forgets from writing a second prefix for the same site (issue #38).
+ */
+function site_segment(site_id: string): string {
+  validate_key_segment(site_id);
+  return normalize_owner_id(site_id);
+}
+
 /** Ensures a single path segment is safe for S3-style keys (no traversal or extra slashes). */
 export function validate_key_segment(value: string): void {
   if (value === '' || value === '.' || value === '..') {
@@ -30,22 +41,22 @@ export function validate_key_segment(value: string): void {
 
 /** Builds the content-addressed key for a stored file blob. */
 export function sharepoint_data_key(site_id: string, checksum: string): string {
-  validate_key_segment(site_id);
+  const site = site_segment(site_id);
   validate_key_segment(checksum);
-  return `${SHAREPOINT_DATA_PREFIX}/${site_id}/${checksum}`;
+  return `${SHAREPOINT_DATA_PREFIX}/${site}/${checksum}`;
 }
 
 /** Builds the key for a snapshot manifest. */
 export function sharepoint_manifest_key(site_id: string, snapshot_id: string): string {
-  validate_key_segment(site_id);
+  const site = site_segment(site_id);
   validate_key_segment(snapshot_id);
-  return `${SHAREPOINT_MANIFEST_PREFIX}/${site_id}/${snapshot_id}.json`;
+  return `${SHAREPOINT_MANIFEST_PREFIX}/${site}/${snapshot_id}.json`;
 }
 
 /** Builds the prefix for listing all manifests of a site. */
 export function sharepoint_manifest_prefix(site_id: string): string {
-  validate_key_segment(site_id);
-  return `${SHAREPOINT_MANIFEST_PREFIX}/${site_id}/`;
+  const site = site_segment(site_id);
+  return `${SHAREPOINT_MANIFEST_PREFIX}/${site}/`;
 }
 
 /** Returns the root prefix for all SharePoint manifests. */
@@ -55,15 +66,15 @@ export function sharepoint_manifest_root_prefix(): string {
 
 /** Builds the key for a file's version index. */
 export function sharepoint_index_key(site_id: string, file_id: string): string {
-  validate_key_segment(site_id);
+  const site = site_segment(site_id);
   validate_key_segment(file_id);
-  return `${SHAREPOINT_INDEX_PREFIX}/${site_id}/files/${file_id}.json`;
+  return `${SHAREPOINT_INDEX_PREFIX}/${site}/files/${file_id}.json`;
 }
 
 /** Builds the prefix for listing all file indexes of a site. */
 export function sharepoint_index_prefix(site_id: string): string {
-  validate_key_segment(site_id);
-  return `${SHAREPOINT_INDEX_PREFIX}/${site_id}/files/`;
+  const site = site_segment(site_id);
+  return `${SHAREPOINT_INDEX_PREFIX}/${site}/files/`;
 }
 
 /** Returns the root prefix for all SharePoint file indexes. */
@@ -73,20 +84,20 @@ export function sharepoint_index_root_prefix(): string {
 
 /** Builds a unique staging key for multipart upload of a file. */
 export function sharepoint_staging_key(site_id: string, item_id: string): string {
-  validate_key_segment(site_id);
+  const site = site_segment(site_id);
   validate_key_segment(item_id);
   const suffix = randomBytes(4).toString('hex');
-  return `${SHAREPOINT_STAGING_PREFIX}/${site_id}/${item_id}-${suffix}`;
+  return `${SHAREPOINT_STAGING_PREFIX}/${site}/${item_id}-${suffix}`;
 }
 
 /** Builds the prefix for listing staging objects. */
 export function sharepoint_staging_prefix(site_id: string): string {
-  validate_key_segment(site_id);
-  return `${SHAREPOINT_STAGING_PREFIX}/${site_id}/`;
+  const site = site_segment(site_id);
+  return `${SHAREPOINT_STAGING_PREFIX}/${site}/`;
 }
 
 /** Builds the key for the delta cursor state. */
 export function sharepoint_delta_cursor_key(site_id: string): string {
-  validate_key_segment(site_id);
-  return `${SHAREPOINT_META_PREFIX}/${site_id}/delta.json`;
+  const site = site_segment(site_id);
+  return `${SHAREPOINT_META_PREFIX}/${site}/delta.json`;
 }

--- a/packages/sharepoint/src/services/sharepoint-verification.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-verification.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -34,6 +35,7 @@ export class SharePointVerificationService implements SharePointVerificationUseC
     site_id: string,
     snapshot_id: string,
   ): Promise<SharePointVerificationResult> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, snapshot_id);

--- a/packages/sharepoint/src/services/status/sharepoint-status.service.ts
+++ b/packages/sharepoint/src/services/status/sharepoint-status.service.ts
@@ -1,3 +1,4 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointDeltaCursorRepository,
@@ -33,6 +34,7 @@ export class SharePointStatusService implements SharePointStatusUseCase {
     tenant_id: string,
     site_id: string,
   ): Promise<SharePointStatusResult> {
+    site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       const previous_cursor = await this._cursors.load(ctx, site_id);

--- a/packages/sharepoint/tests/unit/services/sharepoint-file-filter.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-file-filter.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `--file-filter` by item ID never matched: the filter was lowercased and Graph
+ * drive item IDs carry uppercase (`01ABCDEF3IOE64NKISMBHZW5RI63OZGLXR`).
+ * SharePoint restore was fixed in #75; restore and save on both workloads
+ * carried the same defect. Live proof: the same save command returned 0 files
+ * before and 1 after.
+ */
+import { describe, it, expect } from 'vitest';
+import 'reflect-metadata';
+import { SharePointRestoreService } from '@/services/sharepoint-restore.service';
+import { SharePointSaveService } from '@/services/sharepoint-save.service';
+import type { SharePointManifestEntry } from '@wisecom/atlas-types';
+
+const ITEM_ID = '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3';
+
+const ENTRY = {
+  file_id: ITEM_ID,
+  file_name: 'Report.docx',
+  parent_path: '/Documents',
+  change_type: 'created',
+  storage_key: 'sharepoint/data/o/abc',
+} as SharePointManifestEntry;
+
+interface Filterable {
+  filter_entries(
+    entries: readonly SharePointManifestEntry[],
+    file_filter?: string[],
+  ): SharePointManifestEntry[];
+}
+
+/** `filter_entries` is private; both services must answer the same way. */
+const services: [string, Filterable][] = [
+  ['restore', SharePointRestoreService.prototype as unknown as Filterable],
+  ['save', SharePointSaveService.prototype as unknown as Filterable],
+];
+
+describe.each(services)('%s file_filter', (_name, service) => {
+  it('matches an item id pasted verbatim from a listing', () => {
+    expect(service.filter_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
+  });
+
+  it('matches an item id typed in any case', () => {
+    expect(service.filter_entries([ENTRY], [ITEM_ID.toLowerCase()])).toHaveLength(1);
+  });
+
+  it('still matches by path', () => {
+    expect(service.filter_entries([ENTRY], ['/documents/report.docx'])).toHaveLength(1);
+  });
+
+  it('excludes what was not asked for', () => {
+    expect(service.filter_entries([ENTRY], ['/Documents/Other.docx'])).toHaveLength(0);
+  });
+
+  it('returns everything when no filter is given', () => {
+    expect(service.filter_entries([ENTRY], [])).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #38.

## Problem

An owner or site identifier is case-insensitive to Microsoft Graph and case-sensitive to S3. Only Outlook folded the case, so:

```
owner segments : ['75A21B57-…-7C231C30F78C', '75a21b57-…-7c231c30f78c']   ← one drive, stored twice
deleteOwnerData(UPPER) → reported 9 deleted, success
segments left  : ['75a21b57-…']                                          ← erasure reported success, data survived
```

That second line is the whole issue: a GDPR erasure that swept an empty prefix, reported the nothing it found there as success, and left every byte retrievable. Same class as #27/#28, reached through a different door. SharePoint was worse -- **no** path normalized `site_id`, not even status.

Graph returns these identifiers lowercase, so the CLI never saw it. The SDK is the exposed surface: an embedder holding an object ID in application state, or an operator pasting one from a portal.

## Fix

**Normalization at each service entry** -- backup, restore, save, catalog, verification, status, deletion, replication, rehydration: 29 call sites. Entry-level rather than key-level because manifests carry `owner_id` as a *field*, and replication builds keys from that field; folding only inside key builders would leave the field un-normalized and replication addressing a prefix that does not exist.

**And in the OneDrive/SharePoint key builders.** Belt and braces, deliberately: 29 hand-written call sites invite forgetting one, and I forgot ten replication entry points on the first pass -- caught by reading the SDK surface, not by a test. The builders make a missed entry point cost a wrong manifest field instead of a split storage tree.

Graph **item** IDs are untouched. They are genuinely case-sensitive, and a staging key embeds one, so the fold is scoped to the owner segment only -- pinned by a test.

## Dead branch

`process_large_file` caught `PreconditionFailed` from `ctx.storage.copy(...)`, which never set a precondition. The issue offered making it live or deleting it; I probed the backend before choosing:

```
conditional copy : IGNORED -- silently OVERWROTE the first writer
copy over WORM   : ALLOWED, OVERWROTE          (new version; the locked version survives)
```

MinIO ignores `IfNoneMatch` on CopyObject, so passing it would produce code that *looks* race-safe and is not. And the race it guarded is benign: `canonical_key` is the SHA-256 of the content, so the loser writes identical bytes. Deleted, with the reasoning and the upgrade condition recorded at the race.

## Out of scope, fixed anyway

`--file-filter` by item ID never matched on **three of four** paths: the filter was lowercased, drive item IDs carry uppercase (`01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3`). #75 fixed `sharepoint-restore` and left `onedrive-restore`, `onedrive-save`, `sharepoint-save`. One line each; leaving known-broken siblings is the pattern this PR is about.

Live, same command, same real snapshot:

```
before fix : Files saved: 0
after fix  : Files saved: 1   → Recordings/Palaveri-…-Meeting Transcript.mp4
```

## Evidence

| | before | after |
|---|---|---|
| OneDrive, two spellings | 2 prefixes | 1 prefix |
| `deleteOwnerData(UPPER)` | reported success, lowercase tree survived | 13 objects + 2 manifests erased, `clean` |
| SharePoint, mixed-case site ID | (never normalized anywhere) | 1 prefix, 57 objects erased, `clean` |
| `--file-filter <ITEM_ID>` | 0 files | 1 file |

All three workloads re-backed up and healthy afterwards. 793 tests (25 new), lint, format, docs build.

## Docs

`docs/onedrive-backup.md`, `docs/reference/sdk.md`, and `docs/reference/cli.md` each gain an "Identifier case" note stating the rule, the item-ID exception, and what the erasure gap looked like.

## Not in scope

`TenantBackupOptions.object_lock_request?: ObjectLockRequest` omits `| undefined` where its three sibling ports include it, which is a real `exactOptionalPropertyTypes` error under `tsc`. It pre-exists this branch (verified by running `tsc` directly on both, bypassing turbo's cache, which had been replaying a stale success) and CI never runs `typecheck` at all, so it is invisible twice over. Filed separately rather than widened into this PR.
