### PR TITLE
fix(storage): index Outlook manifest lookups

### DIFF
--- a/docs/operations/storage-layout.md
+++ b/docs/operations/storage-layout.md
@@ -6,6 +6,9 @@ Each tenant gets its own S3 bucket named `atlas-{tenant_id}`. The bucket contain
 atlas-{tenant_id}/
 ├── _meta/
 │   ├── dek.enc                              # wrapped DEK (encrypted with KEK)
+│   ├── outlook-manifests/                   # encrypted Outlook lookup pointers
+│   │   ├── owners/{mailbox_id}/latest.json  # latest manifest key for incremental backup
+│   │   └── snapshots/{snapshot_id}.json     # manifest key for direct snapshot lookup
 │   └── replication/                         # replication status sidecars
 │       ├── {mailbox_id}/                    # Outlook replication status
 │       ├── onedrive/{owner_id}/             # OneDrive replication status
@@ -43,14 +46,18 @@ For managed service providers backing up multiple tenants, this isolation means 
 
 ### Outlook
 
-| Prefix                   | Contents                                       | Security Notes                                                                 |
-| ------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| `_meta/dek.enc`          | Wrapped data encryption key (one per tenant)   | **Most critical object** -- losing this means losing access to all tenant data |
-| `data/{mailbox}/`        | Encrypted email messages, addressed by SHA-256 | Content is encrypted; S3 metadata is not                                       |
-| `attachments/{mailbox}/` | Encrypted attachments, addressed by SHA-256    | Content is encrypted; S3 metadata is not                                       |
-| `manifests/{mailbox}/`   | Encrypted snapshot manifests (JSON)            | Contains subjects, folder names, delta URLs -- all encrypted                   |
+| Prefix                                         | Contents                                       | Security Notes                                                                 |
+| ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| `_meta/dek.enc`                                | Wrapped data encryption key (one per tenant)   | **Most critical object** -- losing this means losing access to all tenant data |
+| `_meta/outlook-manifests/owners/{mailbox}/`    | Pointer to the latest Outlook manifest         | Encrypted; updated after each successful manifest upload                       |
+| `_meta/outlook-manifests/snapshots/{snapshot}` | Pointer from snapshot ID to its manifest key   | Encrypted; avoids a tenant-wide manifest listing                               |
+| `data/{mailbox}/`                              | Encrypted email messages, addressed by SHA-256 | Content is encrypted; S3 metadata is not                                       |
+| `attachments/{mailbox}/`                       | Encrypted attachments, addressed by SHA-256    | Content is encrypted; S3 metadata is not                                       |
+| `manifests/{mailbox}/`                         | Encrypted snapshot manifests (JSON)            | Contains subjects, folder names, delta URLs -- all encrypted                   |
 
 Each Outlook manifest records an optional `mailbox_purpose` field -- the Graph `mailboxSettings.userPurpose` value (`user`, `shared`, `room`, ...) at backup time. This makes shared mailboxes auditable: they are typically unlicensed and therefore invisible to license-based inventories, but the manifest flag identifies them in the backup catalog. Converting a user mailbox to a shared mailbox keeps its Entra object ID, so the `manifests/{mailbox}/` prefix stays stable across the conversion: manifests written before the conversion read `user`, later ones read `shared`, and content blobs under `data/{mailbox}/` (addressed by SHA-256) are shared across both -- message data is stored once. Manifests written before this field existed simply omit it.
+
+The lookup pointers keep incremental backup reads constant as snapshot history grows: Atlas reads the owner's `latest.json` pointer and then that one manifest. Buckets created by older Atlas versions remain compatible. Their first incremental run after upgrade falls back to the existing manifest scan; saving the new snapshot creates the pointers used by later runs. The pointers contain only an encrypted manifest object key and are removed with their mailbox or snapshot.
 
 ### OneDrive
 

--- a/packages/core/src/services/deletion/deletion.service.ts
+++ b/packages/core/src/services/deletion/deletion.service.ts
@@ -20,6 +20,7 @@ import { logger } from '@/utils/logger';
  * with the DEK, so they have to go before the key that reads them.
  */
 const DEK_KEY = '_meta/dek.enc';
+const OUTLOOK_MANIFEST_POINTER_PREFIX = '_meta/outlook-manifests';
 
 @injectable()
 export class DeletionService implements DeletionUseCase {
@@ -36,8 +37,25 @@ export class DeletionService implements DeletionUseCase {
   async delete_mailbox_data(tenant_id: string, owner_id: string): Promise<DeletionResult> {
     owner_id = normalize_owner_id(owner_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    const manifest_prefix = `manifests/${owner_id}/`;
+    const [manifest_keys, manifest_versions] = await Promise.all([
+      storage.list(manifest_prefix),
+      storage.list_versions(manifest_prefix),
+    ]);
+    const snapshot_ids = new Set<string>();
+    for (const key of [...manifest_keys, ...manifest_versions.map((version) => version.key)]) {
+      if (!key.startsWith(manifest_prefix) || !key.endsWith('.json')) continue;
+      const snapshot_id = key.slice(manifest_prefix.length, -'.json'.length);
+      if (snapshot_id.length > 0) snapshot_ids.add(snapshot_id);
+    }
+    const snapshot_pointers = [...snapshot_ids].map(
+      (snapshot_id) => `${OUTLOOK_MANIFEST_POINTER_PREFIX}/snapshots/${snapshot_id}.json`,
+    );
+
     return delete_scopes(storage, [
-      `manifests/${owner_id}/`,
+      manifest_prefix,
+      ...snapshot_pointers,
+      `${OUTLOOK_MANIFEST_POINTER_PREFIX}/owners/${owner_id}/`,
       `data/${owner_id}/`,
       `attachments/${owner_id}/`,
     ]);
@@ -59,11 +77,19 @@ export class DeletionService implements DeletionUseCase {
       }
 
       const key = `manifests/${manifest.owner_id}/${manifest.snapshot_id}.json`;
-      const summary = await delete_scopes(ctx.storage, [key]);
-      if (summary.retained_manifests > 0 || summary.failed_manifests > 0) {
-        logger.error('Snapshot manifest is protected by Object Lock and cannot be deleted yet.');
+      const manifest_summary = await delete_scopes(ctx.storage, [key]);
+      if (has_survivors(manifest_summary)) {
+        if (manifest_summary.retained_manifests > 0 || manifest_summary.failed_manifests > 0) {
+          logger.error('Snapshot manifest is protected by Object Lock and cannot be deleted yet.');
+        }
+        return manifest_summary;
       }
-      return summary;
+
+      const pointer_summary = await delete_scopes(ctx.storage, [
+        `${OUTLOOK_MANIFEST_POINTER_PREFIX}/snapshots/${snapshot_id}.json`,
+        `${OUTLOOK_MANIFEST_POINTER_PREFIX}/owners/${manifest.owner_id}/latest.json`,
+      ]);
+      return merge_deletion_results(manifest_summary, pointer_summary);
     } finally {
       ctx.destroy();
     }

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -103,26 +103,41 @@ describe('DeletionService', () => {
   // ---------------------------------------------------------------------------
 
   describe('delete_mailbox_data', () => {
-    it('deletes data, attachment, and manifest keys for a mailbox', async () => {
-      const list_fn = vi.mocked(mock_context.storage.list);
-      list_fn
-        .mockResolvedValueOnce(['manifests/user@test.com/snap-1.json'])
-        .mockResolvedValueOnce(['data/user@test.com/aaa', 'data/user@test.com/bbb'])
-        .mockResolvedValueOnce(['attachments/user@test.com/ccc']);
+    it('deletes data, attachments, manifests, and lookup pointers for a mailbox', async () => {
+      const objects_by_prefix: Record<string, string[]> = {
+        'manifests/user@test.com/': ['manifests/user@test.com/snap-1.json'],
+        '_meta/outlook-manifests/snapshots/snap-1.json': [
+          '_meta/outlook-manifests/snapshots/snap-1.json',
+        ],
+        '_meta/outlook-manifests/owners/user@test.com/': [
+          '_meta/outlook-manifests/owners/user@test.com/latest.json',
+        ],
+        'data/user@test.com/': ['data/user@test.com/aaa', 'data/user@test.com/bbb'],
+        'attachments/user@test.com/': ['attachments/user@test.com/ccc'],
+      };
+      vi.mocked(mock_context.storage.list).mockImplementation(
+        async (prefix) => objects_by_prefix[prefix] ?? [],
+      );
 
       const result = await service.delete_mailbox_data('t', 'user@test.com');
 
-      expect(result.deleted_objects).toBe(3);
+      expect(result.deleted_objects).toBe(5);
       expect(result.deleted_manifests).toBe(1);
       expect(result.retained_objects).toBe(0);
       expect(result.retained_manifests).toBe(0);
       expect(result.failed_objects).toBe(0);
       expect(result.failed_manifests).toBe(0);
-      expect(mock_context.storage.delete).toHaveBeenCalledTimes(4);
+      expect(mock_context.storage.delete).toHaveBeenCalledTimes(6);
       expect(mock_context.storage.delete).toHaveBeenCalledWith('data/user@test.com/aaa');
       expect(mock_context.storage.delete).toHaveBeenCalledWith('attachments/user@test.com/ccc');
       expect(mock_context.storage.delete).toHaveBeenCalledWith(
         'manifests/user@test.com/snap-1.json',
+      );
+      expect(mock_context.storage.delete).toHaveBeenCalledWith(
+        '_meta/outlook-manifests/snapshots/snap-1.json',
+      );
+      expect(mock_context.storage.delete).toHaveBeenCalledWith(
+        '_meta/outlook-manifests/owners/user@test.com/latest.json',
       );
     });
 
@@ -132,6 +147,9 @@ describe('DeletionService', () => {
       expect(mock_context.storage.list).toHaveBeenCalledWith('manifests/alice@corp.com/');
       expect(mock_context.storage.list).toHaveBeenCalledWith('data/alice@corp.com/');
       expect(mock_context.storage.list).toHaveBeenCalledWith('attachments/alice@corp.com/');
+      expect(mock_context.storage.list).toHaveBeenCalledWith(
+        '_meta/outlook-manifests/owners/alice@corp.com/',
+      );
     });
 
     it('returns zeros when mailbox has no data', async () => {
@@ -156,21 +174,36 @@ describe('DeletionService', () => {
   // ---------------------------------------------------------------------------
 
   describe('delete_snapshot', () => {
-    it('deletes the manifest key and retains data objects', async () => {
+    it('deletes the manifest key and its lookup pointers while retaining data', async () => {
       vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
         make_manifest({ owner_id: 'u@t.com', snapshot_id: 'snap-42' }),
       );
-      vi.mocked(mock_context.storage.list).mockResolvedValueOnce([
-        'manifests/u@t.com/snap-42.json',
-      ]);
+      const objects_by_prefix: Record<string, string[]> = {
+        'manifests/u@t.com/snap-42.json': ['manifests/u@t.com/snap-42.json'],
+        '_meta/outlook-manifests/snapshots/snap-42.json': [
+          '_meta/outlook-manifests/snapshots/snap-42.json',
+        ],
+        '_meta/outlook-manifests/owners/u@t.com/latest.json': [
+          '_meta/outlook-manifests/owners/u@t.com/latest.json',
+        ],
+      };
+      vi.mocked(mock_context.storage.list).mockImplementation(
+        async (prefix) => objects_by_prefix[prefix] ?? [],
+      );
 
       const result = await service.delete_snapshot('t', 'snap-42');
 
       expect(result.deleted_manifests).toBe(1);
-      expect(result.deleted_objects).toBe(0);
+      expect(result.deleted_objects).toBe(2);
       expect(result.retained_manifests).toBe(0);
       expect(mock_context.storage.delete).toHaveBeenCalledWith('manifests/u@t.com/snap-42.json');
-      expect(mock_context.storage.delete).toHaveBeenCalledTimes(1);
+      expect(mock_context.storage.delete).toHaveBeenCalledWith(
+        '_meta/outlook-manifests/snapshots/snap-42.json',
+      );
+      expect(mock_context.storage.delete).toHaveBeenCalledWith(
+        '_meta/outlook-manifests/owners/u@t.com/latest.json',
+      );
+      expect(mock_context.storage.delete).toHaveBeenCalledTimes(3);
     });
 
     it('returns zeros when snapshot is not found', async () => {

--- a/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
@@ -5,10 +5,24 @@ import type { TenantContext } from '@wisecom/atlas-types';
 import type { StorageObjectLockPolicy } from '@wisecom/atlas-types';
 
 const MANIFEST_PREFIX = 'manifests';
+const MANIFEST_POINTER_PREFIX = '_meta/outlook-manifests';
+const MANIFEST_READ_CONCURRENCY = 8;
+
+interface ManifestPointer {
+  readonly manifest_key: string;
+}
 
 /** Constructs the S3 key for a manifest. */
 function manifest_key(owner_id: string, snapshot_id: string): string {
   return `${MANIFEST_PREFIX}/${owner_id}/${snapshot_id}.json`;
+}
+
+function latest_pointer_key(owner_id: string): string {
+  return `${MANIFEST_POINTER_PREFIX}/owners/${owner_id}/latest.json`;
+}
+
+function snapshot_pointer_key(snapshot_id: string): string {
+  return `${MANIFEST_POINTER_PREFIX}/snapshots/${snapshot_id}.json`;
 }
 
 /**
@@ -24,55 +38,85 @@ export class S3ManifestRepository implements ManifestRepository {
     const encrypted = ctx.encrypt(json);
     const object_lock_policy = to_storage_object_lock_policy(manifest);
     await ctx.storage.put(key, encrypted, undefined, object_lock_policy);
+
+    const pointer = ctx.encrypt(
+      Buffer.from(JSON.stringify({ manifest_key: key } satisfies ManifestPointer)),
+    );
+    await Promise.all([
+      ctx.storage.put(snapshot_pointer_key(manifest.snapshot_id), pointer),
+      ctx.storage.put(latest_pointer_key(manifest.owner_id), pointer),
+    ]);
   }
 
-  /** Searches all mailbox prefixes for a manifest matching the snapshot ID. */
+  /** Loads a manifest through its snapshot index, with a legacy layout fallback. */
   async find_by_snapshot(ctx: TenantContext, snapshot_id: string): Promise<Manifest | undefined> {
-    const all_keys = await ctx.storage.list(`${MANIFEST_PREFIX}/`);
     const target_suffix = `/${snapshot_id}.json`;
-    const match = all_keys.find((k) => k.endsWith(target_suffix));
+    const indexed_key = await this.download_pointer(ctx, snapshot_pointer_key(snapshot_id));
+    if (indexed_key?.endsWith(target_suffix)) {
+      const indexed_manifest = await this.download_and_decrypt(ctx, indexed_key);
+      if (indexed_manifest?.snapshot_id === snapshot_id) return indexed_manifest;
+    }
 
+    const all_keys = await ctx.storage.list(`${MANIFEST_PREFIX}/`);
+    const match = all_keys.find((key) => key.endsWith(target_suffix));
     if (!match) return undefined;
     return this.download_and_decrypt(ctx, match);
   }
 
-  /**
-   * Lists manifests for a mailbox owner, parses their created_at timestamps,
-   * and returns the most recent one.
-   */
+  /** Returns the indexed latest manifest, with a legacy layout fallback. */
   async find_latest_by_owner(ctx: TenantContext, owner_id: string): Promise<Manifest | undefined> {
     const prefix = `${MANIFEST_PREFIX}/${owner_id}/`;
-    const keys = await ctx.storage.list(prefix);
-
-    if (keys.length === 0) return undefined;
-
-    let latest: Manifest | undefined;
-
-    for (const key of keys) {
-      const manifest = await this.download_and_decrypt(ctx, key);
-      if (!manifest) continue;
-
-      const is_newer =
-        !latest || new Date(manifest.created_at).getTime() > new Date(latest.created_at).getTime();
-      if (is_newer) {
-        latest = manifest;
-      }
+    const indexed_key = await this.download_pointer(ctx, latest_pointer_key(owner_id));
+    if (indexed_key?.startsWith(prefix)) {
+      const indexed_manifest = await this.download_and_decrypt(ctx, indexed_key);
+      if (indexed_manifest?.owner_id === owner_id) return indexed_manifest;
     }
 
+    const keys = await ctx.storage.list(prefix);
+    if (keys.length === 0) return undefined;
+
+    const manifests = await this.download_manifests(ctx, keys);
+    let latest: Manifest | undefined;
+    for (const manifest of manifests) {
+      const is_newer =
+        !latest || new Date(manifest.created_at).getTime() > new Date(latest.created_at).getTime();
+      if (is_newer) latest = manifest;
+    }
     return latest;
   }
 
-  /** Downloads and decrypts every manifest in the tenant bucket. */
+  /** Downloads every manifest with bounded storage concurrency. */
   async list_all_manifests(ctx: TenantContext): Promise<Manifest[]> {
     const keys = await ctx.storage.list(`${MANIFEST_PREFIX}/`);
-    const results: Manifest[] = [];
+    return this.download_manifests(ctx, keys);
+  }
 
-    for (const key of keys) {
-      const manifest = await this.download_and_decrypt(ctx, key);
-      if (manifest) results.push(manifest);
+  private async download_pointer(ctx: TenantContext, key: string): Promise<string | undefined> {
+    try {
+      const encrypted = await ctx.storage.get(key);
+      const json = ctx.decrypt(encrypted);
+      const parsed = JSON.parse(json.toString('utf-8')) as Partial<ManifestPointer>;
+      return typeof parsed.manifest_key === 'string' ? parsed.manifest_key : undefined;
+    } catch {
+      return undefined;
     }
+  }
 
-    return results;
+  private async download_manifests(ctx: TenantContext, keys: string[]): Promise<Manifest[]> {
+    const results = new Array<Manifest | undefined>(keys.length);
+    let next_index = 0;
+
+    const run_worker = async (): Promise<void> => {
+      while (next_index < keys.length) {
+        const index = next_index;
+        next_index++;
+        results[index] = await this.download_and_decrypt(ctx, keys[index]!);
+      }
+    };
+
+    const worker_count = Math.min(MANIFEST_READ_CONCURRENCY, keys.length);
+    await Promise.all(Array.from({ length: worker_count }, run_worker));
+    return results.filter((manifest): manifest is Manifest => manifest !== undefined);
   }
 
   /** Downloads an encrypted manifest blob, decrypts it, and parses the JSON. */

--- a/packages/s3/tests/unit/s3-manifest-repository.test.ts
+++ b/packages/s3/tests/unit/s3-manifest-repository.test.ts
@@ -59,6 +59,10 @@ function make_manifest(overrides: Partial<Manifest> = {}): Manifest {
   };
 }
 
+function encrypted_json(value: unknown): Buffer {
+  return Buffer.concat([Buffer.from('ENC:'), Buffer.from(JSON.stringify(value))]);
+}
+
 describe('S3ManifestRepository', () => {
   let repo: S3ManifestRepository;
   let ctx: TenantContext;
@@ -69,14 +73,17 @@ describe('S3ManifestRepository', () => {
   });
 
   describe('save', () => {
-    it('encrypts and stores manifest at correct key', async () => {
+    it('stores the manifest and its encrypted lookup pointers', async () => {
       const manifest = make_manifest();
       await repo.save(ctx, manifest);
 
-      expect(ctx.encrypt).toHaveBeenCalledOnce();
-      expect(ctx.storage.put).toHaveBeenCalledOnce();
-      const [key] = (ctx.storage.put as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(key).toBe('manifests/user@test.com/snap-1.json');
+      expect(ctx.encrypt).toHaveBeenCalledTimes(2);
+      const put_calls = vi.mocked(ctx.storage.put).mock.calls;
+      expect(put_calls.map((call) => call[0])).toEqual([
+        'manifests/user@test.com/snap-1.json',
+        '_meta/outlook-manifests/snapshots/snap-1.json',
+        '_meta/outlook-manifests/owners/user@test.com/latest.json',
+      ]);
     });
 
     it('applies effective object lock policy to manifest uploads', async () => {
@@ -95,7 +102,7 @@ describe('S3ManifestRepository', () => {
 
       await repo.save(ctx, manifest);
 
-      const put_call = (ctx.storage.put as ReturnType<typeof vi.fn>).mock.calls[0];
+      const put_call = vi.mocked(ctx.storage.put).mock.calls[0]!;
       expect(put_call[3]).toEqual({
         mode: 'GOVERNANCE',
         retain_until: '2026-04-08T12:00:00.000Z',
@@ -104,15 +111,30 @@ describe('S3ManifestRepository', () => {
   });
 
   describe('find_by_snapshot', () => {
-    it('returns manifest when found by snapshot suffix', async () => {
+    it('loads an indexed snapshot without listing owner prefixes', async () => {
       const manifest = make_manifest();
-      const json = Buffer.from(JSON.stringify(manifest));
-      const encrypted = Buffer.concat([Buffer.from('ENC:'), json]);
+      const pointer = encrypted_json({
+        manifest_key: 'manifests/user@test.com/snap-1.json',
+      });
+      vi.mocked(ctx.storage.get)
+        .mockResolvedValueOnce(pointer)
+        .mockResolvedValueOnce(encrypted_json(manifest));
 
-      (ctx.storage.list as ReturnType<typeof vi.fn>).mockResolvedValue([
-        'manifests/user@test.com/snap-1.json',
-      ]);
-      (ctx.storage.get as ReturnType<typeof vi.fn>).mockResolvedValue(encrypted);
+      const result = await repo.find_by_snapshot(ctx, 'snap-1');
+
+      expect(result?.snapshot_id).toBe('snap-1');
+      expect(ctx.storage.list).not.toHaveBeenCalled();
+      expect(ctx.storage.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the legacy manifest layout', async () => {
+      const manifest = make_manifest();
+      const encrypted = encrypted_json(manifest);
+
+      vi.mocked(ctx.storage.get)
+        .mockRejectedValueOnce(new Error('snapshot pointer not found'))
+        .mockResolvedValueOnce(encrypted);
+      vi.mocked(ctx.storage.list).mockResolvedValue(['manifests/user@test.com/snap-1.json']);
 
       const result = await repo.find_by_snapshot(ctx, 'snap-1');
       expect(result).toBeDefined();
@@ -120,7 +142,8 @@ describe('S3ManifestRepository', () => {
     });
 
     it('returns undefined when no match', async () => {
-      (ctx.storage.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      vi.mocked(ctx.storage.get).mockRejectedValueOnce(new Error('snapshot pointer not found'));
+      vi.mocked(ctx.storage.list).mockResolvedValue([]);
 
       const result = await repo.find_by_snapshot(ctx, 'nonexistent');
       expect(result).toBeUndefined();
@@ -128,6 +151,25 @@ describe('S3ManifestRepository', () => {
   });
 
   describe('find_latest_by_owner', () => {
+    it('loads the indexed latest manifest without scanning snapshot history', async () => {
+      const manifest = make_manifest({
+        snapshot_id: 'snap-new',
+        created_at: new Date('2026-06-01T00:00:00Z'),
+      });
+      const pointer = encrypted_json({
+        manifest_key: 'manifests/user@test.com/snap-new.json',
+      });
+      const encrypted = encrypted_json(manifest);
+
+      vi.mocked(ctx.storage.get).mockResolvedValueOnce(pointer).mockResolvedValueOnce(encrypted);
+
+      const result = await repo.find_latest_by_owner(ctx, 'user@test.com');
+
+      expect(result?.snapshot_id).toBe('snap-new');
+      expect(ctx.storage.list).not.toHaveBeenCalled();
+      expect(ctx.storage.get).toHaveBeenCalledTimes(2);
+    });
+
     it('returns the most recent manifest', async () => {
       const older = make_manifest({
         id: 'old',
@@ -140,16 +182,17 @@ describe('S3ManifestRepository', () => {
         created_at: new Date('2026-06-01T00:00:00Z'),
       });
 
-      const enc_old = Buffer.concat([Buffer.from('ENC:'), Buffer.from(JSON.stringify(older))]);
-      const enc_new = Buffer.concat([Buffer.from('ENC:'), Buffer.from(JSON.stringify(newer))]);
+      const enc_old = encrypted_json(older);
+      const enc_new = encrypted_json(newer);
 
-      (ctx.storage.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      vi.mocked(ctx.storage.get)
+        .mockRejectedValueOnce(new Error('latest pointer not found'))
+        .mockResolvedValueOnce(enc_old)
+        .mockResolvedValueOnce(enc_new);
+      vi.mocked(ctx.storage.list).mockResolvedValue([
         'manifests/user@test.com/snap-old.json',
         'manifests/user@test.com/snap-new.json',
       ]);
-      (ctx.storage.get as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce(enc_old)
-        .mockResolvedValueOnce(enc_new);
 
       const result = await repo.find_latest_by_owner(ctx, 'user@test.com');
       expect(result).toBeDefined();
@@ -157,10 +200,62 @@ describe('S3ManifestRepository', () => {
     });
 
     it('returns undefined for empty mailbox', async () => {
-      (ctx.storage.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      vi.mocked(ctx.storage.get).mockRejectedValueOnce(new Error('latest pointer not found'));
+      vi.mocked(ctx.storage.list).mockResolvedValue([]);
 
       const result = await repo.find_latest_by_owner(ctx, 'user@test.com');
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('list_all_manifests', () => {
+    it('bounds parallel manifest downloads', async () => {
+      const keys = Array.from(
+        { length: 12 },
+        (_, index) => `manifests/user@test.com/snap-${index}.json`,
+      );
+      let in_flight = 0;
+      let max_in_flight = 0;
+      let started = 0;
+      let signal_first_batch!: () => void;
+      let signal_all_started!: () => void;
+      const first_batch_started = new Promise<void>((resolve) => {
+        signal_first_batch = resolve;
+      });
+      const all_downloads_started = new Promise<void>((resolve) => {
+        signal_all_started = resolve;
+      });
+      const pending_releases: (() => void)[] = [];
+      vi.mocked(ctx.storage.list).mockResolvedValue(keys);
+      vi.mocked(ctx.storage.get).mockImplementation(
+        (key) =>
+          new Promise<Buffer>((resolve) => {
+            in_flight++;
+            started++;
+            max_in_flight = Math.max(max_in_flight, in_flight);
+            if (in_flight === 8) signal_first_batch();
+            if (started === keys.length) signal_all_started();
+            pending_releases.push(() => {
+              in_flight--;
+              const snapshot_id = key.split('/').at(-1)!.replace('.json', '');
+              resolve(encrypted_json(make_manifest({ snapshot_id })));
+            });
+          }),
+      );
+
+      const manifests_promise = repo.list_all_manifests(ctx);
+      await first_batch_started;
+
+      expect(ctx.storage.get).toHaveBeenCalledTimes(8);
+      expect(max_in_flight).toBe(8);
+      for (const release of pending_releases.splice(0)) release();
+
+      await all_downloads_started;
+      for (const release of pending_releases.splice(0)) release();
+      const manifests = await manifests_promise;
+
+      expect(manifests).toHaveLength(keys.length);
+      expect(max_in_flight).toBe(8);
     });
   });
 });


### PR DESCRIPTION
Closes #35.

## Problem

`find_latest_by_owner` listed, downloaded, and decrypted every historical Outlook manifest before each incremental backup. The Nth backup therefore performed O(N) manifest reads, and normal daily use accumulated O(N²) storage traffic. Snapshot lookup also listed the full tenant manifest tree, while catalog/statistics reads were strictly sequential.

## Fix

- Save encrypted `_meta/outlook-manifests` pointers for each snapshot and each owner's latest manifest.
- Resolve current-format latest and snapshot lookups with one pointer GET plus one manifest GET, without LIST.
- Preserve old buckets: missing/stale pointers fall back to the legacy layout; the next successful backup writes current pointers.
- Bound bulk manifest downloads at eight concurrent storage reads.
- Remove pointer objects during snapshot and mailbox deletion, including indexes derived from versioned manifest keys.
- Document the pointer layout and upgrade behavior.

## Evidence

- `pnpm --filter @wisecom/atlas-s3 exec vitest run tests/unit/s3-manifest-repository.test.ts` — 9 passed.
- `pnpm --filter @wisecom/atlas-core exec vitest run tests/unit/services/deletion/deletion.service.test.ts` — 15 passed.
- `pnpm --filter @wisecom/atlas-s3 typecheck` — passed.
- ESLint on all four changed TypeScript files — passed.
- Prettier check on all five changed files — passed.
- `pnpm run docs:build` — completed; VitePress emitted the repository's existing `cron`/`env` syntax-language warnings.

The full core typecheck remains blocked in unchanged `verification.service.ts:59` by the existing `VerificationResult.unverifiable` declaration-resolution mismatch; neither that service nor its port differs from `release/v2.1.0-beta`.