### PR TITLE
fix(graph): retry the transient 500 and 502 Graph raises under load

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -139,7 +139,7 @@ See [Programmatic SDK](./reference/sdk.md) for full method signatures and option
 | `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`          |
 | `-t, --tenant <id>`        | Tenant identifier                                    | Config default    |
 
-Restored files are uploaded to the target user's primary drive. Folders are created as needed (existing folders with the same name are reused, not overwritten). Each file is decrypted, SHA-256 verified against the manifest checksum, and then uploaded using a small-file PUT (&le; 4 MiB) or a resumable upload session (> 4 MiB, with per-chunk retry on 429/503).
+Restored files are uploaded to the target user's primary drive. Folders are created as needed (existing folders with the same name are reused, not overwritten). Each file is decrypted, SHA-256 verified against the manifest checksum, and then uploaded using a small-file PUT (&le; 4 MiB) or a resumable upload session (> 4 MiB, with per-chunk retry on any transient Graph status: 429, 500, 502, 503, 504). A range PUT is addressed by its `Content-Range`, so a replayed chunk rewrites the same bytes rather than appending them twice.
 
 Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is read from S3 as a stream, the first 28 bytes (12-byte IV + 16-byte auth tag) are consumed to initialize AES-256-GCM, and ciphertext is decrypted in chunks without buffering the full ciphertext in memory.
 

--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -37,14 +37,18 @@ Delta links are stored in the **encrypted manifest**, not in plaintext. They con
 
 ## Retry and Error Handling
 
-Microsoft Graph applies rate limiting to protect the service. Atlas handles this transparently:
+Microsoft Graph applies rate limiting to protect the service, and its front end returns transient server errors under load. Atlas handles both transparently:
 
-| Error                              | Behavior                                                           |
-| ---------------------------------- | ------------------------------------------------------------------ |
-| **HTTP 429** (Too Many Requests)   | Honors `Retry-After` header, exponential backoff, up to 12 retries |
-| **HTTP 503** (Service Unavailable) | Same retry logic as 429                                            |
-| **HTTP 504** (Gateway Timeout)     | Same retry logic as 429                                            |
-| **`syncStateNotFound`**            | Delta token expired or invalid -- automatic full resync            |
+| Error                                | Behavior                                                           |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| **HTTP 429** (Too Many Requests)     | Honors `Retry-After` header, exponential backoff, up to 12 retries |
+| **HTTP 500** (Internal Server Error) | Same retry logic as 429                                            |
+| **HTTP 502** (Bad Gateway)           | Same retry logic as 429                                            |
+| **HTTP 503** (Service Unavailable)   | Same retry logic as 429                                            |
+| **HTTP 504** (Gateway Timeout)       | Same retry logic as 429                                            |
+| **`syncStateNotFound`**              | Delta token expired or invalid -- automatic full resync            |
+
+`500` and `502` are retried because Graph raises them for load and gateway faults that clear on their own; a single one mid-folder would otherwise fail that folder (Outlook) or discard the drive batch (OneDrive/SharePoint). `501` and every `4xx` are not retried -- repeating them returns the same answer.
 
 When a delta token has expired (Microsoft purges them after ~30 days of inactivity), Graph returns a `syncStateNotFound` error. Atlas detects this and automatically falls back to a full enumeration for that folder, logging a warning so you know the incremental chain was broken.
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -354,11 +354,11 @@ Implementation thresholds from `@wisecom/atlas-sharepoint`:
 
 | Size                          | Strategy                                                                                                                                                                                       |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **<= 4 MiB**                  | Single read via pre-authenticated URL (with 429 retry + Retry-After backoff) or Graph content fallback, encrypt, `put`                                                                         |
+| **<= 4 MiB**                  | Single read via pre-authenticated URL (with transient-status retry + Retry-After backoff) or Graph content fallback, encrypt, `put`                                                            |
 | **> 4 MiB** and **< 512 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                                      |
 | **>= 512 MiB**                | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
 
-Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff) so a transient failure replays a single chunk instead of the whole file.
+Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff) so a transient failure replays a single chunk instead of the whole file. A chunk is retried on the same statuses as any other Graph call -- 429, 500, 502, 503, and 504 -- because the CDN in front of Graph raises `500` and `502` under load; `4xx` responses fail the chunk immediately.
 
 ## OneNote Notebooks
 
@@ -396,9 +396,9 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ## Download Resilience
 
-SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.graph.downloadUrl`) are subject to Microsoft Graph rate limiting. Atlas handles this with:
+SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.graph.downloadUrl`) are subject to Microsoft Graph rate limiting, and the CDN also returns transient gateway faults of its own. Atlas handles this with:
 
-- **429 detection** on direct download URLs with `Retry-After` header parsing (supports both delta-seconds and HTTP-date formats).
+- **Transient-status detection** on direct download URLs -- `429`, `500`, `502`, `503`, and `504` are retried, with `Retry-After` header parsing (supports both delta-seconds and HTTP-date formats).
 - **Exponential backoff** when `Retry-After` is absent (base 1s, max 32s, with jitter).
 - **Graph content fallback** -- if the pre-authenticated URL fails after retries, Atlas falls back to `GET /drives/{drive_id}/items/{item_id}/content` which routes through the Graph gateway rather than the CDN.
 
@@ -433,10 +433,10 @@ console.log(`Restored: ${result.files_restored} files, ${result.folders_created}
 
 **File size handling during restore:**
 
-| Size         | Strategy                                                                                               |
-| ------------ | ------------------------------------------------------------------------------------------------------ |
-| **<= 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content`                |
-| **> 4 MiB**  | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429/503) |
+| Size         | Strategy                                                                                                               |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **<= 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content`                                |
+| **> 4 MiB**  | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429, 500, 502, 503, 504) |
 
 Files with `change_type: 'deleted'` or missing `storage_key` are skipped. Checksum verification runs before upload -- corrupted blobs are skipped with a warning.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,9 +26,9 @@ Error: ClientSecretCredential authentication failed
 
 If the error message is ambiguous, cross-check in the Azure Portal under **Microsoft Entra ID → Sign-in logs → Application sign-ins**, filtering by your application's client ID.
 
-## Graph API 429 Throttling
+## Graph API 429 Throttling and Transient 5xx
 
-HTTP 429 responses from Microsoft Graph are normal and expected during large backups. They are not errors requiring intervention.
+HTTP 429 responses from Microsoft Graph are normal and expected during large backups. They are not errors requiring intervention. The same is true of occasional `500 InternalServerError` and `502 Bad Gateway` responses: Graph raises them under load, and Atlas retries them on the same schedule as a 429 rather than failing the folder or drive batch.
 
 ### What it looks like in logs
 
@@ -43,6 +43,8 @@ Atlas honors Microsoft's `Retry-After` header and retries up to **12 times** wit
 - **Occasional 429s during large initial backups**: normal. Microsoft throttles per-application and per-mailbox. Atlas handles these automatically.
 - **Persistent 429s causing repeated folder failures**: this usually means you have too many concurrent workers (`-C` flag) for your tenant's allocated Graph API capacity. Try reducing to `-C 2` or `-C 1`.
 - **429s on every request from the start**: check whether another application in your tenant is also consuming heavy Graph API quota. Contact Microsoft support if the throttle limits seem unusually low.
+- **Occasional 500/502 responses**: normal under load, retried automatically. A run that logs a handful and completes needs no action.
+- **Persistent 500/502 on the same item**: not throttling. Retries are exhausted against a server-side fault; re-run the backup later and, if it repeats, open a Microsoft support case with the request IDs from `--log-level debug`.
 
 ### Throughput ceiling
 

--- a/packages/m365-graph/src/graph-error-helpers.ts
+++ b/packages/m365-graph/src/graph-error-helpers.ts
@@ -1,6 +1,18 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
-const RETRYABLE_STATUS_CODES = new Set([429, 503, 504]);
+/**
+ * Statuses Graph recovers from on its own, per Microsoft's throttling and
+ * resilience guidance: the request never reached a working backend, or the
+ * gateway gave up on one. 501 and every 4xx stay out -- repeating those
+ * returns the same answer.
+ *
+ * ponytail: one set for reads and writes. A 500 on a create POST can retry a
+ * request the backend already committed, which restore surfaces as a duplicate
+ * item -- the same exposure 504 already carried. Thread an idempotency flag
+ * through GraphRetryOptions and opt the restore writers out if duplicates ever
+ * show up in practice.
+ */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 const NETWORK_ERROR_CODES = new Set([
   'ETIMEDOUT',
   'ECONNRESET',
@@ -95,7 +107,7 @@ export function rethrow_if_mailbox_not_licensed(err: unknown): void {
   }
 }
 
-/** Returns true when the error carries a transient HTTP status (429, 503, 504). */
+/** Returns true when the error carries a transient HTTP status (429, 500, 502, 503, 504). */
 export function is_transient_error(err: unknown): boolean {
   const status = (err as Record<string, unknown>).statusCode;
   return typeof status === 'number' && RETRYABLE_STATUS_CODES.has(status);
@@ -131,7 +143,7 @@ export function is_retryable_error(err: unknown): boolean {
 
 /**
  * Wraps any async network call with exponential backoff + jitter for both
- * transient HTTP errors (429, 503, 504) and network-level errors (ETIMEDOUT,
+ * transient HTTP errors (429, 500, 502, 503, 504) and network-level errors (ETIMEDOUT,
  * ECONNRESET, socket hang up, etc.).
  *
  * Retries up to 12 times with delays capped at 5 minutes, giving a total

--- a/packages/m365-graph/tests/unit/graph-error-helpers.test.ts
+++ b/packages/m365-graph/tests/unit/graph-error-helpers.test.ts
@@ -66,12 +66,16 @@ describe('is_invalid_delta_error', () => {
 });
 
 describe('is_transient_error', () => {
-  it.each([429, 503, 504])('returns true for status %i', (status) => {
+  it.each([429, 500, 502, 503, 504])('returns true for status %i', (status) => {
     expect(is_transient_error({ statusCode: status })).toBe(true);
   });
 
   it('returns false for 400', () => {
     expect(is_transient_error({ statusCode: 400 })).toBe(false);
+  });
+
+  it('returns false for 501, which Graph does not recover from by itself', () => {
+    expect(is_transient_error({ statusCode: 501 })).toBe(false);
   });
 });
 
@@ -149,6 +153,22 @@ describe('with_graph_retry', () => {
     const fn = (): Promise<string> => {
       calls++;
       if (calls === 1) return Promise.reject({ statusCode: 503, message: 'Service Unavailable' });
+      return Promise.resolve('recovered');
+    };
+
+    const promise = with_graph_retry(fn);
+    await vi.advanceTimersByTimeAsync(60_000);
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  it.each([500, 502])('retries a transient %i and succeeds', async (status) => {
+    let calls = 0;
+    const fn = (): Promise<string> => {
+      calls++;
+      if (calls === 1) return Promise.reject({ statusCode: status, message: 'Server error' });
       return Promise.resolve('recovered');
     };
 

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -1,5 +1,5 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_retryable_error } from '@wisecom/atlas-m365-graph';
+import { is_retryable_error, is_transient_error } from '@wisecom/atlas-m365-graph';
 
 /** Maximum bytes per HTTP Range chunk (4 MiB). */
 export const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
@@ -174,9 +174,9 @@ async function download_single_chunk(
 }
 
 function is_cdn_retryable(err: unknown): boolean {
-  if (err instanceof CdnHttpError) {
-    return err.status_code === 429 || err.status_code === 503 || err.status_code === 504;
-  }
+  // One classifier for Graph and the CDN in front of it: a 500 or 502 on a
+  // chunk is as transient here as on any other Graph call (issue #36).
+  if (err instanceof CdnHttpError) return is_transient_error({ statusCode: err.status_code });
   return is_retryable_error(err);
 }
 

--- a/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@microsoft/microsoft-graph-client';
-import { with_graph_retry } from '@wisecom/atlas-m365-graph';
+import { is_transient_error, with_graph_retry } from '@wisecom/atlas-m365-graph';
 
 const LARGE_UPLOAD_CHUNK = 10 * 1024 * 1024;
 const CHUNK_PUT_ATTEMPTS = 3;
@@ -45,7 +45,9 @@ async function put_upload_chunk_with_retry(
     if (response.ok) return;
 
     last_detail = await response.text();
-    const retriable = response.status === 429 || response.status === 503;
+    // A range PUT is addressed by Content-Range, so replaying one after a
+    // transient 500/502/504 rewrites the same bytes (issue #36).
+    const retriable = is_transient_error({ statusCode: response.status });
     const is_last = attempt === CHUNK_PUT_ATTEMPTS - 1;
     if (retriable && !is_last) {
       const wait_ms = parse_fetch_retry_after_ms(response.headers.get('retry-after')) ?? 1000;
@@ -150,7 +152,8 @@ export async function graph_onedrive_upload_small_file(
 
 /**
  * Uploads via createUploadSession and chunked PUTs. Each chunk PUT is retried up to three times on
- * 429/503 with Retry-After delays; on terminal failure the upload session is cancelled with DELETE.
+ * a transient Graph status (429, 500, 502, 503, 504) with Retry-After delays; on terminal failure
+ * the upload session is cancelled with DELETE.
  */
 export async function graph_onedrive_upload_large_file(
   client: Client,

--- a/packages/onedrive/tests/unit/adapters/graph-onedrive-chunked-download.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-onedrive-chunked-download.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { download_file_chunked } from '@/adapters/graph-onedrive-chunked-download';
+
+// Issue #36: Graph and the CDN in front of it return transient 500/502 under
+// load. A chunk that hits one must be retried, not turned into a skipped file.
+
+function to_array_buffer(body: Buffer): ArrayBuffer {
+  const copy = new ArrayBuffer(body.byteLength);
+  new Uint8Array(copy).set(body);
+  return copy;
+}
+
+function range_response(status: number, body = Buffer.alloc(0)): Response {
+  return {
+    status,
+    headers: { get: (): string | null => null },
+    arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
+    text: (): Promise<string> => Promise.resolve(''),
+  } as unknown as Response;
+}
+
+describe('download_file_chunked', () => {
+  const payload = Buffer.from('chunk-payload');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([500, 502])('retries a chunk that failed with HTTP %i', async (status) => {
+    const fetch_mock = vi
+      .fn()
+      .mockResolvedValueOnce(range_response(status))
+      .mockResolvedValueOnce(range_response(206, payload));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const promise = download_file_chunked('https://cdn.test/file', payload.length, 'item-1');
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(await promise).toEqual(payload);
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails a chunk that returned HTTP 404 without retrying', async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(404));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    await expect(
+      download_file_chunked('https://cdn.test/file', payload.length, 'item-1'),
+    ).rejects.toThrow('HTTP 404');
+    expect(fetch_mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts
@@ -1,5 +1,5 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_retryable_error } from '@wisecom/atlas-m365-graph';
+import { is_retryable_error, is_transient_error } from '@wisecom/atlas-m365-graph';
 
 export const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
 export const CHUNK_DOWNLOAD_THRESHOLD = 4 * 1024 * 1024;
@@ -166,9 +166,9 @@ async function download_single_chunk(
 }
 
 function is_cdn_retryable(err: unknown): boolean {
-  if (err instanceof CdnHttpError) {
-    return err.status_code === 429 || err.status_code === 503 || err.status_code === 504;
-  }
+  // One classifier for Graph and the CDN in front of it: a 500 or 502 on a
+  // chunk is as transient here as on any other Graph call (issue #36).
+  if (err instanceof CdnHttpError) return is_transient_error({ statusCode: err.status_code });
   return is_retryable_error(err);
 }
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@microsoft/microsoft-graph-client';
-import { with_graph_retry } from '@wisecom/atlas-m365-graph';
+import { is_transient_error, with_graph_retry } from '@wisecom/atlas-m365-graph';
 
 const LARGE_UPLOAD_CHUNK = 10 * 1024 * 1024;
 const CHUNK_PUT_ATTEMPTS = 3;
@@ -45,7 +45,9 @@ async function put_upload_chunk_with_retry(
     if (response.ok) return;
 
     last_detail = await response.text();
-    const retriable = response.status === 429 || response.status === 503;
+    // A range PUT is addressed by Content-Range, so replaying one after a
+    // transient 500/502/504 rewrites the same bytes (issue #36).
+    const retriable = is_transient_error({ statusCode: response.status });
     const is_last = attempt === CHUNK_PUT_ATTEMPTS - 1;
     if (retriable && !is_last) {
       const wait_ms = parse_fetch_retry_after_ms(response.headers.get('retry-after')) ?? 1000;
@@ -147,8 +149,9 @@ export async function graph_sharepoint_upload_small_file(
 }
 
 /**
- * Uploads via createUploadSession and chunked PUTs. Each chunk is retried up to three times on
- * 429/503 with Retry-After delays; on terminal failure the upload session is cancelled.
+ * Uploads via createUploadSession and chunked PUTs. Each chunk is retried up to three times on a
+ * transient Graph status (429, 500, 502, 503, 504) with Retry-After delays; on terminal failure the
+ * upload session is cancelled.
  */
 export async function graph_sharepoint_upload_large_file(
   client: Client,


### PR DESCRIPTION
Closes #36.

## Problem

`RETRYABLE_STATUS_CODES` held `429, 503, 504`, so a transient `500 InternalServerError` or `502 Bad Gateway` — which Graph raises routinely under load, and which Microsoft's resilience guidance says to retry with backoff — failed the folder (Outlook) or discarded the drive batch (OneDrive/SharePoint) on first contact.

Grepping the callers turned up two more copies of the same hardcoded set, both of which the ticket's one-line fix would have left broken:

- `is_cdn_retryable` in the OneDrive and SharePoint chunked download paths: `429 || 503 || 504`, so a CDN `500`/`502` on a 4 MiB range failed the chunk and, after 5 attempts, the file.
- `put_upload_chunk_with_retry` in both restore adapters: `429 || 503`, so a transient gateway fault mid-upload aborted the whole resumable session (which is then cancelled with DELETE).

## Fix

- `RETRYABLE_STATUS_CODES` is now `429, 500, 502, 503, 504`. `501` and every `4xx` stay out — repeating those returns the same answer.
- Both CDN chunk predicates and both upload-chunk predicates now delegate to `is_transient_error`, so there is one place that decides what "transient" means.
- Retrying a range PUT is safe by construction: the chunk is addressed by its `Content-Range`, so a replay rewrites the same bytes.

The widened set applies to non-idempotent Graph writes too (restore's create-message POST), which is the exposure `504` already carried: a request the backend committed before the gateway gave up can be replayed. The constant carries a `ponytail:` note naming the upgrade path — an idempotency flag on `GraphRetryOptions` that the restore writers opt out of — if duplicates ever show up in practice.

## Evidence

The acceptance case (`500` → `200` succeeds, no error surfaced) and its `502` twin are pinned in `graph-error-helpers.test.ts`, alongside a `501` case that stops the set from drifting into "any 5xx".

A new `graph-onedrive-chunked-download.test.ts` drives the real chunk loop against a stubbed `fetch`: `500`/`502` are retried and the payload arrives, while `404` fails the chunk on the first attempt.

- `pnpm --filter @wisecom/atlas-m365-graph test` — 72 passed (3 files).
- `pnpm --filter @wisecom/atlas-onedrive test` — 71 passed (12 files).
- `pnpm --filter @wisecom/atlas-sharepoint test` — 141 passed (16 files).
- `typecheck` for all three packages plus `@wisecom/atlas-core` — clean.
- `lint` and `format:check` for all three packages — clean (only the repo's pre-existing warnings in untouched files).
- `pnpm run docs:build` — completed.

## Docs

`docs/operations/delta-sync.md` gains `500`/`502` rows and states why `501`/`4xx` are excluded. `docs/troubleshooting.md` explains what an occasional `500`/`502` means versus a persistent one. `docs/onedrive-backup.md` and `docs/sharepoint-backup.md` update the per-chunk retry statuses for download and restore.

## Commits

1. `fix(graph): retry the transient 500 and 502 Graph raises under load` — the shared classifier, its tests, and the operator-facing docs.
2. `fix(files): classify CDN chunk and upload retries with the Graph rules` — the four sibling predicates, the chunk-loop test, and the workload docs.